### PR TITLE
Code Smell: equality operators should not be used in for loop termina…

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
@@ -117,7 +117,7 @@ var AnnotatorUI = (function($, window, undefined) {
       var clearSelection = function() {
         window.getSelection().removeAllRanges();
         if (selRect != null) {
-          for(var s=0; s != selRect.length; s++) {
+          for(var s=0; s < selRect.length; s++) {
             selRect[s].parentNode.removeChild(selRect[s]);
           }
           selRect = null;


### PR DESCRIPTION
Code smell: Replacing the "not equals to (!=)" operator as the bounding condition with a "less than (<)" operator in the following "for loop".
Explaination:
for(var s=0; s != selRect.length; s++)
The bounding condition used in the above code is "!=". This is used to set the boundary of the loop. Whenever the value of variable 's' is equal to that of the size of 'selRect' the loop is exited. The use of the "not equals" operator is also a good choice, but when all the cases, including exceptional cases, are considered, there is the possibility that the value of 's' might become greater than that of 'selRect' size. In such cases, the loop will never stop and run till infinity. It is always a good choice to use a comparator operator such as "less than", "less than or equal to", "greater than", "greater than or equal to" to set the boundary conditions.
Proposed Solution:
To solve the above code smell, I intend to use a "less than" comparison operator. The loop starts from 0 to less than the size of "selRect". In the original code, the loop exits if "s==selRect.length", which means the value of s should never be equal to that of the size of "selRect". Hence a "less than (<)" comparison operator is the best alternative to the "not equal to" operator.

Change:
At line number 120 change the condition from "!=" to "<".