### PR TITLE
unused PROP_USER private field is removed

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -146,7 +146,7 @@ public class AeroRemoteApiController
     private static final String PROP_ID = "id";
     private static final String PROP_NAME = "name";
     private static final String PROP_STATE = "state";
-    private static final String PROP_USER = "user";
+    
     private static final String PROP_TIMESTAMP = "user";
 
     private static final String FORMAT_DEFAULT = "text";


### PR DESCRIPTION
code smell: 
Unused "private" fields should be removed.
Explanation:
 If a private field is declared but not used in the program, it can be considered dead code which will lead to problems in maintainability.
Solution:
To solve the above code smell I removed the dead code i.e removing the unused PROP_USER private field, this will improve maintainability because developers will not wonder what the variable is used for.