### PR TITLE
Removed "APPLICATION_JSON_UTF8" as it is deprecated.

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -166,7 +166,7 @@ public class AeroRemoteApiController
         throws IOException
     {
         LOG.error(aException.getMessage(), aException);
-        return ResponseEntity.status(aException.getStatus()).contentType(APPLICATION_JSON_UTF8)
+        return ResponseEntity.status(aException.getStatus()).contentType(APPLICATION_JSON_VALUE)
                 .body(new RResponse<>(ERROR, aException.getMessage()));
     }
 


### PR DESCRIPTION
code smell: 
"@Deprecated" code should not be used.
Explanation:
Once deprecated, classes, and interfaces, and their members should be avoided, rather than used, inherited, or extended. Deprecation is a warning that the class or interface has been superseded, and will eventually be removed. The deprecation period allows you to make a smooth transition away from the aging, soon-to-be-retired technology.
Solution:
To solve the above code smell I removed "APPLICATION_JSON_UTF8" as it is deprecated and replaced it with "APPLICATION_JSON_VALUE".