### PR TITLE
Modifiers declared in the incorrect order.

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/footer/WarningsFooterPanel.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/footer/WarningsFooterPanel.java
@@ -45,7 +45,7 @@ public class WarningsFooterPanel
 {
     private static final long serialVersionUID = 2586844743503672765L;
 
-    private final static Logger LOG = LoggerFactory.getLogger(WarningsFooterPanel.class);
+    private static final Logger LOG = LoggerFactory.getLogger(WarningsFooterPanel.class);
 
     private @SpringBean DatabaseDriverService dbDriverService;
 


### PR DESCRIPTION
What is the issue/code smell?
Java modifiers are declared the incorrect order.
Why is this issue/ code smell relevant?
This causes a minor impact as doesn't cause any technical problems but as most of the developers follow the standard order which says "static" should be before "final" that can reduce the readability of the code.
How is the issue resolved?
Reordering the modifiers to comply with the Java Language Specification i.e., changing the order from "public final static" to
" public static final".