### PR TITLE
Return values are ignored when they contain the operation status code

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -35,6 +35,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.*;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -394,7 +395,7 @@ public class AeroRemoteApiController
             importedProject = exportService.importProject(request, new ZipFile(tempFile));
         }
         finally {
-            tempFile.delete();
+            Files.delete(tempFile);
         }
 
         return ResponseEntity.ok(new RResponse<>(new RProject(importedProject)));


### PR DESCRIPTION
Bug: 
delete() method of java.io.file package is not a preferred method to delete a file.
Explanation: 
the java.io.files package uses a stream-oriented package so moving back and forth is not possible. And, the thread will be blocked until it completes the I/O operation.
Solution:
 Use java.nio.files package instead. It is a buffer-oriented package that provides flexibility in handling data and can use back and forth in buffer and provide more efficient and extensive access to additional file operations, file attributes, and I/O exceptions to help diagnose errors when an operation on a file fails.
