### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/NameUtil.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/NameUtil.java
@@ -19,6 +19,10 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.core.page;
 
 public class NameUtil
 {
+    private NameUtil()
+    {
+    throw new IllegalStateException("Utility class");
+    }
     /**
      * Check if the name is valid, SPecial characters are not allowed as a project/user name as it
      * will conflict with file naming system
@@ -34,9 +38,9 @@ public class NameUtil
                 || aName.contains("+") || aName.contains("$") || aName.contains("!")
                 || aName.contains("[") || aName.contains("]")) {
             return false;
-        }
+             }
         else {
             return true;
-        }
+            }
     }
 }


### PR DESCRIPTION
What is the code smell/issue?
Utility classes should not have public constructors
How is this issue relevant?
Utility classes, which are collections of static members, are not meant to be instantiated. Even abstract utility classes, which can be extended, should not have public constructors.
Java adds an implicit public constructor to every class which does not define at least one explicitly. Hence, at least one non-public constructor should be defined.
How can this issue be resolved?
we can add a private constructor to hide the implicit public one.