### PR TITLE
block of commented-out lines of code is removed.

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -389,7 +389,7 @@ public class AeroRemoteApiController
                 throw new UnsupportedFormatException("Incompatible to webanno ZIP file");
             }
 
-            // importedProject = importService.importProject(tempFile, false);
+           
             ProjectImportRequest request = new ProjectImportRequest(false);
             importedProject = exportService.importProject(request, new ZipFile(tempFile));
         }


### PR DESCRIPTION
Code smell:
Sections of code should not be commented out.
Explanation:
Programmers should not comment out code as it bloats programs and reduces readability.
Unused code should be deleted and can be retrieved from source control history if required.
Solution:
To solve the above code smell I removed the commented-out lines.