### PR TITLE
Boxed Boolean should be handled carefully in boolean expressions

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
@@ -135,8 +135,8 @@ public class ManageUsersPage
 
         private void validateEnabled(IValidatable<Boolean> aValidatable)
         {
-            if (!aValidatable.getValue()
-                    && userRepository.getCurrentUser().equals(getModelObject())) {
+            if (Boolean.TRUE.equals(aValidatable.getValue()
+                    && userRepository.getCurrentUser().equals(getModelObject()))) {
                 aValidatable.error(
                         new ValidationError().setMessage("You cannot disable your own account."));
             }


### PR DESCRIPTION
What is the code issue/smell, and is it relevant? 
Boxed Boolean should be avoided in boolean expressions because it throws a null pointer exception if the value is invalid, and autoboxing will be applied directly by java & therefore, it increases complexity.
How to resolve it? 
By implementing primitive boolean expressions, it is safer to avoid such conversion altogether and handle the null value explicitly.