### PR TITLE
Constructors of an "abstract" class should not be declared "public" issue2

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/settings/ProjectSettingsPanelBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/settings/ProjectSettingsPanelBase.java
@@ -32,7 +32,7 @@ public abstract class ProjectSettingsPanelBase
         super(id);
     }
 
-    public ProjectSettingsPanelBase(String id, IModel<Project> aProjectModel)
+    protected ProjectSettingsPanelBase(String id, IModel<Project> aProjectModel)
     {
         super(id, aProjectModel);
     }


### PR DESCRIPTION
What is the code smell/issue?
Constructors of an "abstract" class should not be declared "public"
Why is this code smell relevant?
Abstract classes should not have public constructors. Constructors of abstract classes can only be called in constructors of their subclasses. So there is no point in making them public
How is this issue resolved?
Changing the modifier from public to protected can resolve this issue.