### PR TITLE
'java.nio.Files#delete' should be preferred

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.*;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.invoke.MethodHandle;
@@ -394,7 +395,7 @@ public class AeroRemoteApiController
             importedProject = exportService.importProject(request, new ZipFile(tempFile));
         }
         finally {
-            tempFile.delete();
+            Files.delete(tempFile);
         }
 
         return ResponseEntity.ok(new RResponse<>(new RProject(importedProject)));


### PR DESCRIPTION
code smell:
'java.nio.Files#delete' should be preferred.
Explanation:
When java.io.File#delete fails, this boolean method simply returns false with no indication of the cause. On the other hand, when java.nio.file.Files#delete fails, this void method returns one of a series of exception types to better indicate the cause of the failure
Solution:
To solve the above code smell I used java.nio.file.Files#delete, since more information is generally better in a debugging situation.