### PR TITLE
Deprecated Code #3

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -281,6 +281,7 @@ public abstract class WicketApplicationBase
 
     protected void initShowExceptionPage()
     {
+        @SuppressWarnings("deprecation")
         Properties settings = SettingsUtil.getSettings();
         if ("true".equalsIgnoreCase(settings.getProperty("debug.showExceptionPage"))) {
             getExceptionSettings()
@@ -290,6 +291,7 @@ public abstract class WicketApplicationBase
 
     protected void initLogoReference()
     {
+        @SuppressWarnings("deprecation")
         Properties settings = SettingsUtil.getSettings();
         String logoValue = settings.getProperty(SettingsUtil.CFG_STYLE_LOGO);
         if (StringUtils.isNotBlank(logoValue) && new File(logoValue).canRead()) {
@@ -348,6 +350,7 @@ public abstract class WicketApplicationBase
 
     protected void initServerTimeReporting()
     {
+        @SuppressWarnings("deprecation")
         Properties settings = SettingsUtil.getSettings();
         if (!DEVELOPMENT.equals(getConfigurationType())
                 && !"true".equalsIgnoreCase(settings.getProperty("debug.sendServerSideTimings"))) {


### PR DESCRIPTION
What is the code smell/issue found?
Deprecated classes, interfaces should be avoided for using, inheriting, extending. Deprecation is basically an indication that a particular class has been superseded and will be eventually be removed. The deprecation period allows us to make a smooth transition away from the aging, soon-to-be-retired technology.

How is this code smell relevant?
Deprecated code is code that is very old in age and no longer being used, this can increase the complexity and will make maintainability of the code difficult.

How can we resolve this issue?
Using @SuppressWarnings annotation disables the compiler warnings, in our case about the deprecated code.