### PR TITLE
Annotation detail pannel placement

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.html
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.html
@@ -16,18 +16,18 @@
   limitations under the License.
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-  xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+      xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
 <body>
-  <wicket:panel>
-    <div class="scrolling flex-content fit-child-loose text-center" style="min-height: unset;">
-      <div class="brat">
-        <div wicket:id="vis"></div>
-        <div wicket:id="contextMenu" style="width: 250px;"></div>
-        <div id="messagepullup" class="messages" style="display: none"></div>
-        <div id="commentpopup"></div>
-        <div id="document_name"></div>
-      </div>
+<wicket:panel>
+  <div class="scrolling flex-content fit-child-loose text-center" style="min-height: unset;">
+    <div class="brat">
+      <div wicket:id="vis"></div>
+      <div wicket:id="contextMenu" style="width: 250px;"></div>
+      <div id="messagepullup" class="messages" style="display: none"></div>
+      <div id="commentpopup" ></div>
+      <div id="document_name"></div>
     </div>
-  </wicket:panel>
+  </div>
+</wicket:panel>
 </body>
 </html>

--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/visualizer_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/visualizer_ui.js
@@ -24,1137 +24,1158 @@
 // vim:set ft=javascript ts=2 sw=2 sts=2 cindent:
 var VisualizerUI = (function($, window, undefined) {
     var VisualizerUI = function(dispatcher, svg) {
-      var that = this;
+        var that = this;
 
-      var messagePostOutFadeDelay = 1000;
-      var messageDefaultFadeDelay = 3000;
-      var defaultFloatFormat = '%.1f/right';
+        var messagePostOutFadeDelay = 1000;
+        var messageDefaultFadeDelay = 3000;
+        var defaultFloatFormat = '%.1f/right';
 
-      var documentListing = null; // always documents of current collection
-      var selectorData = null;    // can be search results when available
-      var searchActive = false;   // whether search results received and in use
-      var loadedSearchData = null;
+        var documentListing = null; // always documents of current collection
+        var selectorData = null;    // can be search results when available
+        var searchActive = false;   // whether search results received and in use
+        var loadedSearchData = null;
 
-      var currentForm;
-      var spanTypes = null;
-      var relationTypesHash = null;
-      // TODO: confirm unnecessary and remove
+        var currentForm;
+        var spanTypes = null;
+        var relationTypesHash = null;
+        // TODO: confirm unnecessary and remove
 //       var attributeTypes = null;
-      var data = null;
-      var mtime = null;
-      var searchConfig = null;
-      var coll, doc, args;
-      var collScroll;
-      var docScroll;
-      var user = null;
-      var annotationAvailable = false;
+        var data = null;
+        var mtime = null;
+        var searchConfig = null;
+        var coll, doc, args;
+        var collScroll;
+        var docScroll;
+        var user = null;
+        var annotationAvailable = false;
 
-      var svgElement = $(svg._svg);
-      var svgId = svgElement.parent().attr('id');
+        var svgElement = $(svg._svg);
+        var svgId = svgElement.parent().attr('id');
 
-      var maxMessages = 100;
+        var maxMessages = 100;
 
-      var currentDocumentSVGsaved = false;
-      var fileBrowserClosedWithSubmit = false;
+        var currentDocumentSVGsaved = false;
+        var fileBrowserClosedWithSubmit = false;
 
 
-      // normalization: server-side DB by norm DB name
-      var normServerDbByNormDbName = {};
+        // normalization: server-side DB by norm DB name
+        var normServerDbByNormDbName = {};
 
-      var matchFocus = '';
-      var matches = '';
-
-// WEBANNO EXTENSION BEGIN
-// Not required by WebAnno
-/*
-      // START "no svg" message - related
-
-      var noSvgTimer = null;
-
-      // this is necessary for centering
-      $('#no_svg_wrapper').css('display', 'table');
-      // on initial load, hide the "no SVG" message
-      $('#no_svg_wrapper').hide();
-
-      var hideNoDocMessage = function() {
-        clearTimeout(noSvgTimer);
-        $('#no_svg_wrapper').hide(0);
-        $('#source_files').show();
-      }
-
-      var showNoDocMessage = function() {
-        clearTimeout(noSvgTimer);
-        noSvgTimer = setTimeout(function() {
-          $('#no_svg_wrapper').fadeIn(500);
-        }, 2000);
-        $('#source_files').hide();
-      }
-      
-      // END "no svg" message - related
-*/
-// WEBANNO EXTENSION END
+        var matchFocus = '';
+        var matches = '';
 
 // WEBANNO EXTENSION BEGIN
 // Not required by WebAnno
-/*
-      // START collection browser sorting - related
+        /*
+              // START "no svg" message - related
 
-      var lastGoodCollection = '/';
-      var sortOrder = [2, 1]; // column (0..), sort order (1, -1)
-      var collectionSortOrder; // holds previous sort while search is active
-      var docSortFunction = function(a, b) {
-          // parent at the top
-          if (a[2] === '..') return -1;
-          if (b[2] === '..') return 1;
+              var noSvgTimer = null;
 
-          // then other collections
-          var aIsColl = a[0] == "c";
-          var bIsColl = b[0] == "c";
-          if (aIsColl !== bIsColl) return aIsColl ? -1 : 1;
+              // this is necessary for centering
+              $('#no_svg_wrapper').css('display', 'table');
+              // on initial load, hide the "no SVG" message
+              $('#no_svg_wrapper').hide();
 
-          // desired column in the desired order
-          var col = sortOrder[0];
-          var aa = a[col];
-          var bb = b[col];
-          if (selectorData.header[col - 2][1] === 'string-reverse') {
-            aa = aa.split('').reverse().join('');
-            bb = bb.split('').reverse().join('');
-          }
-          if (aa != bb) return (aa < bb) ? -sortOrder[1] : sortOrder[1];
-
-          // prevent random shuffles on columns with duplicate values
-          // (alphabetical order of documents)
-          aa = a[2];
-          bb = b[2];
-          if (aa != bb) return (aa < bb) ? -1 : 1;
-          return 0;
-      };
-
-      var makeSortChangeFunction = function(sort, th, thNo) {
-          $(th).click(function() {
-              // TODO: avoid magic numbers in access to the selector
-              // data (column 0 is type, 1 is args, rest is data)
-              if (sort[0] === thNo + 1) sort[1] = -sort[1];
-              else {
-                var type = selectorData.header[thNo - 1][1];
-                var ascending = type === "string";
-                sort[0] = thNo + 1;
-                sort[1] = ascending ? 1 : -1;
+              var hideNoDocMessage = function() {
+                clearTimeout(noSvgTimer);
+                $('#no_svg_wrapper').hide(0);
+                $('#source_files').show();
               }
-              selectorData.items.sort(docSortFunction);
-              docScroll = 0;
-              showFileBrowser(); // resort
-          });
-      }
 
-      // END collection browser sorting - related
-*/
+              var showNoDocMessage = function() {
+                clearTimeout(noSvgTimer);
+                noSvgTimer = setTimeout(function() {
+                  $('#no_svg_wrapper').fadeIn(500);
+                }, 2000);
+                $('#source_files').hide();
+              }
+
+              // END "no svg" message - related
+        */
+// WEBANNO EXTENSION END
+
+// WEBANNO EXTENSION BEGIN
+// Not required by WebAnno
+        /*
+              // START collection browser sorting - related
+
+              var lastGoodCollection = '/';
+              var sortOrder = [2, 1]; // column (0..), sort order (1, -1)
+              var collectionSortOrder; // holds previous sort while search is active
+              var docSortFunction = function(a, b) {
+                  // parent at the top
+                  if (a[2] === '..') return -1;
+                  if (b[2] === '..') return 1;
+
+                  // then other collections
+                  var aIsColl = a[0] == "c";
+                  var bIsColl = b[0] == "c";
+                  if (aIsColl !== bIsColl) return aIsColl ? -1 : 1;
+
+                  // desired column in the desired order
+                  var col = sortOrder[0];
+                  var aa = a[col];
+                  var bb = b[col];
+                  if (selectorData.header[col - 2][1] === 'string-reverse') {
+                    aa = aa.split('').reverse().join('');
+                    bb = bb.split('').reverse().join('');
+                  }
+                  if (aa != bb) return (aa < bb) ? -sortOrder[1] : sortOrder[1];
+
+                  // prevent random shuffles on columns with duplicate values
+                  // (alphabetical order of documents)
+                  aa = a[2];
+                  bb = b[2];
+                  if (aa != bb) return (aa < bb) ? -1 : 1;
+                  return 0;
+              };
+
+              var makeSortChangeFunction = function(sort, th, thNo) {
+                  $(th).click(function() {
+                      // TODO: avoid magic numbers in access to the selector
+                      // data (column 0 is type, 1 is args, rest is data)
+                      if (sort[0] === thNo + 1) sort[1] = -sort[1];
+                      else {
+                        var type = selectorData.header[thNo - 1][1];
+                        var ascending = type === "string";
+                        sort[0] = thNo + 1;
+                        sort[1] = ascending ? 1 : -1;
+                      }
+                      selectorData.items.sort(docSortFunction);
+                      docScroll = 0;
+                      showFileBrowser(); // resort
+                  });
+              }
+
+              // END collection browser sorting - related
+        */
 // WEBANNO EXTENSION END
 
 
-      /* START message display - related */
+        /* START message display - related */
 
-      var showPullupTrigger = function() {
-        $('#pulluptrigger').show('puff');
-      }
+        var showPullupTrigger = function() {
+            $('#pulluptrigger').show('puff');
+        }
 
-      var $messageContainer = $('#messages');
-      var $messagepullup = $('#messagepullup');
-      var pullupTimer = null;
-      var displayMessages = function(msgs) {
-        var initialMessageNum = $messagepullup.children().length;
+        var $messageContainer = $('#messages');
+        var $messagepullup = $('#messagepullup');
+        var pullupTimer = null;
+        var displayMessages = function(msgs) {
+            var initialMessageNum = $messagepullup.children().length;
 
-        if (msgs === false) {
-          $messageContainer.children().each(function(msgElNo, msgEl) {
-              $(msgEl).remove();
-          });
-        } else {
-          $.each(msgs, function(msgNo, msg) {
-            var element;
-            var timer = null;
-            try {
-              element = $('<div class="' + msg[1] + '">' + msg[0] + '</div>');
-            }
-            catch(x) {
-              escaped = msg[0].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-              element = $('<div class="error"><b>[ERROR: could not display the following message normally due to malformed XML:]</b><br/>' + escaped + '</div>');
-            }
-            var pullupElement = element.clone();
-            $messageContainer.append(element);
-            $messagepullup.append(pullupElement.css('display', 'none'));
-            slideToggle(pullupElement, true, true);
-
-            var fader = function() {
-              if ($messagepullup.is(':visible')) {
-                element.remove();
-              } else {
-                element.hide('slow', function() {
-                  element.remove();
+            if (msgs === false) {
+                $messageContainer.children().each(function(msgElNo, msgEl) {
+                    $(msgEl).remove();
                 });
-              }
-            };
-            var delay = (msg[2] === undefined)
-                          ? messageDefaultFadeDelay
-                          : (msg[2] === -1)
-                              ? null
-                              : (msg[2] * 1000);
-            if (delay === null) {
-              var button = $('<input type="button" value="OK"/>');
-              element.prepend(button);
-              button.click(function(evt) {
-                timer = setTimeout(fader, 0);
-              });
             } else {
-              timer = setTimeout(fader, delay);
-              element.mouseover(function() {
-                  clearTimeout(timer);
-                  element.show();
-              }).mouseout(function() {
-                  timer = setTimeout(fader, messagePostOutFadeDelay);
-              });
+                $.each(msgs, function(msgNo, msg) {
+                    var element;
+                    var timer = null;
+                    try {
+                        element = $('<div class="' + msg[1] + '">' + msg[0] + '</div>');
+                    }
+                    catch(x) {
+                        escaped = msg[0].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+                        element = $('<div class="error"><b>[ERROR: could not display the following message normally due to malformed XML:]</b><br/>' + escaped + '</div>');
+                    }
+                    var pullupElement = element.clone();
+                    $messageContainer.append(element);
+                    $messagepullup.append(pullupElement.css('display', 'none'));
+                    slideToggle(pullupElement, true, true);
+
+                    var fader = function() {
+                        if ($messagepullup.is(':visible')) {
+                            element.remove();
+                        } else {
+                            element.hide('slow', function() {
+                                element.remove();
+                            });
+                        }
+                    };
+                    var delay = (msg[2] === undefined)
+                        ? messageDefaultFadeDelay
+                        : (msg[2] === -1)
+                            ? null
+                            : (msg[2] * 1000);
+                    if (delay === null) {
+                        var button = $('<input type="button" value="OK"/>');
+                        element.prepend(button);
+                        button.click(function(evt) {
+                            timer = setTimeout(fader, 0);
+                        });
+                    } else {
+                        timer = setTimeout(fader, delay);
+                        element.mouseover(function() {
+                            clearTimeout(timer);
+                            element.show();
+                        }).mouseout(function() {
+                            timer = setTimeout(fader, messagePostOutFadeDelay);
+                        });
+                    }
+                    // setTimeout(fader, messageDefaultFadeDelay);
+                });
+
+                // limited history - delete oldest
+                var $messages = $messagepullup.children();
+                for (var i = 0; i < $messages.length - maxMessages; i++) {
+                    $($messages[i]).remove();
+                }
             }
-            // setTimeout(fader, messageDefaultFadeDelay);
-          });
 
-          // limited history - delete oldest
-          var $messages = $messagepullup.children();
-          for (var i = 0; i < $messages.length - maxMessages; i++) {
-            $($messages[i]).remove();
-          }
-        }
-
-        // if there is change in the number of messages, may need to
-        // tweak trigger visibility
-        var messageNum = $messagepullup.children().length;
-        if (messageNum != initialMessageNum) {
-          if (messageNum == 0) {
-            // all gone; nothing to trigger
-            $('#pulluptrigger').hide('slow');
-          } else if (initialMessageNum == 0) {
-            // first messages, show trigger at fade
-            setTimeout(showPullupTrigger, messageDefaultFadeDelay+250);
-          }
-        }
-      };
+            // if there is change in the number of messages, may need to
+            // tweak trigger visibility
+            var messageNum = $messagepullup.children().length;
+            if (messageNum != initialMessageNum) {
+                if (messageNum == 0) {
+                    // all gone; nothing to trigger
+                    $('#pulluptrigger').hide('slow');
+                } else if (initialMessageNum == 0) {
+                    // first messages, show trigger at fade
+                    setTimeout(showPullupTrigger, messageDefaultFadeDelay+250);
+                }
+            }
+        };
 
 // WEBANNO EXTENSION BEGIN
 // Not required by WebAnno
-/*
-      // hide pullup trigger by default, show on first message
-      $('#pulluptrigger').hide();
-      $('#pulluptrigger').
-        mouseenter(function(evt) {
-          $('#pulluptrigger').hide('puff');
-          clearTimeout(pullupTimer);
-          slideToggle($messagepullup.stop(), true, true, true);
-        });
-*/
+        /*
+              // hide pullup trigger by default, show on first message
+              $('#pulluptrigger').hide();
+              $('#pulluptrigger').
+                mouseenter(function(evt) {
+                  $('#pulluptrigger').hide('puff');
+                  clearTimeout(pullupTimer);
+                  slideToggle($messagepullup.stop(), true, true, true);
+                });
+        */
 // WEBANNO EXTENSION END
-      $('#messagepullup').
+        $('#messagepullup').
         mouseleave(function(evt) {
-          setTimeout(showPullupTrigger, 500);
-          clearTimeout(pullupTimer);
-          pullupTimer = setTimeout(function() {
-            slideToggle($messagepullup.stop(), false, true, true);
-          }, 500);
+            setTimeout(showPullupTrigger, 500);
+            clearTimeout(pullupTimer);
+            pullupTimer = setTimeout(function() {
+                slideToggle($messagepullup.stop(), false, true, true);
+            }, 500);
         });
 
 
-      /* END message display - related */
+        /* END message display - related */
 
 
-      /* START comment popup - related */
+        /* START comment popup - related */
 
-            var adjustToCursor = function(evt, element, offset, top, right) {
-                    // get the real width, without wrapping
-        			element.css({ left: 0, top: 0 });
-                    var screenHeight = $(window).height();
-                    var screenWidth = $(window).width();
-                    // FIXME why the hell is this 22 necessary?!?
-                    var elementHeight = element.height() + 22;
-                    var elementWidth = element.width() + 22;
-                    var x, y;
-                    offset = offset || 0;
-                    if (top) {
-                        y = evt.clientY - elementHeight - offset;
-                        if (y < 0) top = false;
-                    }
-                    if (!top) {
-                        y = evt.clientY + offset;
-                    }
-                    if (right) {
-                        x = evt.clientX + offset;
-                        if (x >= screenWidth - elementWidth) right = false;
-                    }
-                    if (!right) {
-                        x = evt.clientX - elementWidth - offset;
-                    }
-                    if (y < 0) y = 0;
-                    if (x < 0) x = 0;
-        			element.css({ top: y, left: x });
-                };
+        var adjustToCursor = function(evt, element, offset, top, right) {
+            // get the real width, without wrapping
+            element.css({ left: 0, top: 0 });
+            var screenHeight = $(window).height();
+            var screenWidth = $(window).width();
+            // FIXME why the hell is this 22 necessary?!?
+            var elementHeight = element.height() + 22;
+            var elementWidth = element.width() + 22;
+            var x, y;
+            offset = offset || 0;
+            if (top) {
+                y = evt.clientY - elementHeight - offset;
+                if (y < 0) top = false;
+            }
+            if (!top) {
+                y = evt.clientY + offset;
+            }
+            if (right) {
+                x = evt.clientX + offset;
+                if (x >= screenWidth - elementWidth) right = false;
+            }
+            if (!right) {
+                x = evt.clientX - elementWidth - offset;
+            }
+            if (y < 0) y = 0;
+            if (x < 0) x = 0;
+            element.css({ top: y, left: x });
+            if (y > 210 && y < 270) {
+                y=y-80;
+            }
+            if (y > 270 && y < 300) {
+                y=y-160
+            }
+            else if( y > 300 && y < 360) {
+                y=y-200
+            }
+            else if( y > 360) {
+                y=y-200
+            }
+            $('.annotationpannel').css({ top: y, left: x })
+        };
 
-            var commentPopup = $('#commentpopup');
-            var commentDisplayed = false;
+        var commentPopup = $('#commentpopup');
+        var commentDisplayed = false;
 
-            var displayCommentTimer = null;
-            var displayComment = function(evt, target, comment, commentText, commentType, immediately) {
-                    var idtype;
-                    if (commentType) {
-                        // label comment by type, with special case for default note type
-                        var commentLabel;
-                        if (commentType == 'AnnotatorNotes') {
-                            commentLabel = '<b>Note:</b> ';
-                        } else {
-                            commentLabel = '<b>' + Util.escapeHTML(commentType) + ':</b> ';
-                        }
-                        comment += "<hr/>";
-                        comment += commentLabel + Util.escapeHTMLwithNewlines(commentText);
-                        idtype = 'comment_' + commentType;
-                    }
-                    commentPopup[0].className = idtype;
-                    commentPopup.html(comment);
-                    adjustToCursor(evt, commentPopup, 10, true, true);
-                    clearTimeout(displayCommentTimer);
-/* slight "tooltip" delay to allow highlights to be seen
-           before the popup obstructs them. */
-                    displayCommentTimer = setTimeout(function() {
+        var displayCommentTimer = null;
+        var displayComment = function(evt, target, comment, commentText, commentType, immediately) {
+            var idtype;
+            if (commentType) {
+                // label comment by type, with special case for default note type
+                var commentLabel;
+                if (commentType == 'AnnotatorNotes') {
+                    commentLabel = '<b>Note:</b> ';
+                } else {
+                    commentLabel = '<b>' + Util.escapeHTML(commentType) + ':</b> ';
+                }
+                comment += "<hr/>";
+                comment += commentLabel + Util.escapeHTMLwithNewlines(commentText);
+                idtype = 'comment_' + commentType;
+            }
+            commentPopup[0].className = idtype;
+            commentPopup.html(comment);
+            adjustToCursor(evt, commentPopup, 10, true, true);
+            clearTimeout(displayCommentTimer);
+            /* slight "tooltip" delay to allow highlights to be seen
+                       before the popup obstructs them. */
+            displayCommentTimer = setTimeout(function() {
 // BEGIN WEBANNO EXTENSION - #1610 - Improve brat visualization interaction performance
 // - Show/hide comments immediately instead of using an animation to avoid costly reflows
-/*
-                        commentPopup.stop(true, true).fadeIn(0);
-*/
-                        commentPopup.show();
+                /*
+                                        commentPopup.stop(true, true).fadeIn(0);
+                */
+                // commentPopup.show();
 // END WEBANNO EXTENSION - #1610 - Improve brat visualization interaction performance
-                        commentDisplayed = true;
-                    }, immediately ? 0 : 500);
-                };
+                commentDisplayed = true;
+            }, immediately ? 0 : 500);
+        };
 
-            // to avoid clobbering on delayed response
-            var commentPopupNormInfoSeqId = 0;
+        // to avoid clobbering on delayed response
+        var commentPopupNormInfoSeqId = 0;
 
-            var normInfoSortFunction = function(a, b) {
-                    // images at the top
-                    if (a[0].toLowerCase() == '<img>') return -1;
-                    if (b[0].toLowerCase() == '<img>') return 1;
-                    // otherwise stable
-                    return Util.cmp(a[2], b[2]);
-                }
+        var normInfoSortFunction = function(a, b) {
+            // images at the top
+            if (a[0].toLowerCase() == '<img>') return -1;
+            if (b[0].toLowerCase() == '<img>') return 1;
+            // otherwise stable
+            return Util.cmp(a[2], b[2]);
+        }
 
-// WEBANNO EXTENSION BEGIN - #587 Customize mouse hover text   
-            var displaySpanComment = function(
-                evt, target, spanId, spanType, mods, spanText, hoverText, commentText, commentType, normalizations) {
-// WEBANNO EXTENSION END - #587 Customize mouse hover text
-
-                    var immediately = false;
-                    var comment = ('<div><span class="comment_type_id_wrapper">' + '<span class="comment_type">' + Util.escapeHTML(Util.spanDisplayForm(spanTypes, spanType)) + '</span>' + ' ' + '<span class="comment_id">' + 'ID:' + Util.escapeHTML(spanId) + '</span></span>');
-                    if (mods.length) {
-                        comment += '<div>' + Util.escapeHTML(mods.join(', ')) + '</div>';
-                    }
-
-                    comment += '</div>';
-                    
 // WEBANNO EXTENSION BEGIN - #587 Customize mouse hover text
-                    if (hoverText) {
-                        comment += ('<div class="comment_text">' + Util.escapeHTML(hoverText) + '</div>');
-                    } else if (spanText) {
-                        comment += ('<div class="comment_text">"' + Util.escapeHTML(spanText) + '"</div>');
-                    }
+        var displaySpanComment = function(
+            evt, target, spanId, spanType, mods, spanText, hoverText, commentText, commentType, normalizations) {
 // WEBANNO EXTENSION END - #587 Customize mouse hover text
-                    
-                    var validArcTypesForDrag = dispatcher.post('getValidArcTypesForDrag', [spanId, spanType]);
-                    if (validArcTypesForDrag && validArcTypesForDrag[0]) {
-                        if (validArcTypesForDrag[0].length) {
-                            comment += '<div>' + validArcTypesForDrag[0].join(', ') + '</div>';
-                        } else {
-                            $('rect[data-span-id="' + spanId + '"]').addClass('badTarget');
-                        }
-                        immediately = true;
-                    }
-                    // process normalizations
-                    var normsToQuery = [];
-                    $.each(normalizations, function(normNo, norm) {
-                        var dbName = norm[0],
-                            dbKey = norm[1];
+            $('.annotationpannel').css('display','block')
+            var immediately = false;
+            var comment =('<div><span class="comment_type_id_wrapper">' + '<span class="comment_type">' + Util.escapeHTML(Util.spanDisplayForm(spanTypes, spanType)) + '</span>' + ' ' + '<span class="comment_id">' + 'ID:' + Util.escapeHTML(spanId) + '</span></span>');
+            if (mods.length) {
+                comment += '<div>' + Util.escapeHTML(mods.join(', ')) + '</div>';
+            }
+
+            comment += '</div>';
+// WEBANNO EXTENSION BEGIN - #587 Customize mouse hover text
+            if (hoverText) {
+                comment += ('<div class="comment_text">' + Util.escapeHTML(hoverText) + '</div>');
+
+            } else if (spanText) {
+                comment += ('<div class="comment_text">"' + Util.escapeHTML(spanText) + '"</div>');
+                console.log(spanText)
+                console.log("from line368");
+
+            }
+// WEBANNO EXTENSION END - #587 Customize mouse hover text
+
+            var validArcTypesForDrag = dispatcher.post('getValidArcTypesForDrag', [spanId, spanType]);
+            if (validArcTypesForDrag && validArcTypesForDrag[0]) {
+                if (validArcTypesForDrag[0].length) {
+                    comment += '<div>' + validArcTypesForDrag[0].join(', ') + '</div>';
+                } else {
+                    $('rect[data-span-id="' + spanId + '"]').addClass('badTarget');
+                }
+                immediately = true;
+            }
+            // process normalizations
+            var normsToQuery = [];
+            $.each(normalizations, function(normNo, norm) {
+                var dbName = norm[0],
+                    dbKey = norm[1];
 // WEBANNO EXTENSION BEGIN - #1293 Display information via the brat "normalization" mechanism
-/*
-                        var dbName = norm[0],
-                            dbKey = norm[1];
-                        comment += ('<hr/>' + '<span class="comment_id">' + Util.escapeHTML(dbName) + ':' + Util.escapeHTML(dbKey) + '</span>');
-                        if (dbName in normServerDbByNormDbName && normServerDbByNormDbName[dbName] != '<NONE>') {
-                            // DB available, add drop-off point to HTML and store
-                            // query parameters
-                            commentPopupNormInfoSeqId++;
-                            comment += ('<br/><div id="norm_info_drop_point_' + commentPopupNormInfoSeqId + '"/>');
-                            normsToQuery.push([dbName, dbKey, commentPopupNormInfoSeqId]);
-                        } else {
-                            // no DB, just attach "human-readable" text provided
-                            // with the annotation, if any
-                            if (norm[2]) {
-                                comment += ('<br/><span class="norm_info_value">' + Util.escapeHTML(norm[2]) + '</span>');
-                            }
-                        }
-*/
-                        if (norm[2]) {
-                            var cateogory = norm[0],
-                                key = norm[1];
-                                value = norm[2];
-                            // no DB, just attach "human-readable" text provided
-                            // with the annotation, if any
-                            if (cateogory) {
-                              comment += ```
+                /*
+                                        var dbName = norm[0],
+                                            dbKey = norm[1];
+                                        comment += ('<hr/>' + '<span class="comment_id">' + Util.escapeHTML(dbName) + ':' + Util.escapeHTML(dbKey) + '</span>');
+                                        if (dbName in normServerDbByNormDbName && normServerDbByNormDbName[dbName] != '<NONE>') {
+                                            // DB available, add drop-off point to HTML and store
+                                            // query parameters
+                                            commentPopupNormInfoSeqId++;
+                                            comment += ('<br/><div id="norm_info_drop_point_' + commentPopupNormInfoSeqId + '"/>');
+                                            normsToQuery.push([dbName, dbKey, commentPopupNormInfoSeqId]);
+                                        } else {
+                                            // no DB, just attach "human-readable" text provided
+                                            // with the annotation, if any
+                                            if (norm[2]) {
+                                                comment += ('<br/><span class="norm_info_value">' + Util.escapeHTML(norm[2]) + '</span>');
+                                            }
+                                        }
+                */
+                if (norm[2]) {
+                    var cateogory = norm[0],
+                        key = norm[1];
+                    value = norm[2];
+                    // no DB, just attach "human-readable" text provided
+                    // with the annotation, if any
+                    if (cateogory) {
+                        comment += ```
                                   <hr/>
                                   <span class="comment_id">${Util.escapeHTML(cateogory)}</span>'
                                   ```;
-                            }
-                            
-                            if (key) {
-                              comment += ```
+                    }
+
+                    if (key) {
+                        comment += ```
                                   <span class="norm_info_label">${Util.escapeHTML(key)}</span>
                                   ```;
-                            }
-                            
-                            comment += ```
+                    }
+
+                    comment += ```
                                   <span class="norm_info_value">${Util.escapeHTML(value).replace(/\n/g, "<br/>")}</span>
                                   <br/>
                                   ```;
-                        } else {
-                            // DB available, add drop-off point to HTML and store
-                            // query parameters
-                            var dbName = norm[0],
-                                dbKey = norm[1];
-                            commentPopupNormInfoSeqId++;
-                            comment += ('<hr/>' + '<span class="comment_id">' + Util.escapeHTML(dbName) + ':' + Util.escapeHTML(dbKey) + '</span>');
-                            comment += ('<br/><div id="norm_info_drop_point_' + commentPopupNormInfoSeqId + '"/>');
-                            normsToQuery.push([dbName, dbKey, commentPopupNormInfoSeqId]);
-                        }
-// WEBANNO EXTENSION END - #1293 Display information via the brat "normalization" mechanism
-                    });
-
-                    // display initial comment HTML 
-                    displayComment(evt, target, comment, commentText, commentType, immediately);
-
-                    // initiate AJAX calls for the normalization data to query
-                    $.each(normsToQuery, function(normqNo, normq) {
-                        // TODO: cache some number of most recent norm_get_data results
-                        var dbName = normq[0],
-                            dbKey = normq[1],
-                            infoSeqId = normq[2];
-                        dispatcher.post('ajax', [{
-                            action: 'normData',
-                            database: dbName,
-                            key: dbKey,
-                            collection: coll,
-// WEBANNO EXTENSION BEGIN - #1293 Display information via the brat "normalization" mechanism
-                            id: spanId,
-                            type: spanType,
-// WEBANNO EXTENSION END - #1293 Display information via the brat "normalization" mechanism
-                        }, function(response) {
-                            if (response.exception) {; // TODO: response to error
-// WEBANNO EXTENSION BEGIN - #1293 Display information via the brat "normalization" mechanism
-/*
-                            } else if (!response.value) {; // TODO: response to missing key
-*/
-                            } else if (!response.results) {; // TODO: response to missing key
-// WEBANNO EXTENSION END - #1293 Display information via the brat "normalization" mechanism
-                            } else {
-                                // extend comment popup with normalization data
-                                norminfo = '';
-                                // flatten outer (name, attr, info) array (idx for sort)
-                                infos = [];
-                                var idx = 0;
-// WEBANNO EXTENSION BEGIN - #1293 Display information via the brat "normalization" mechanism
-/*
-                                for (var i = 0; i < response.value.length; i++) {
-                                    for (var j = 0; j < response.value[i].length; j++) {
-                                        var label = response.value[i][j][0];
-                                        var value = response.value[i][j][1];
-                                        infos.push([label, value, idx++]);
-                                    }
-                                }
-*/
-                                for (var j = 0; j < response.results.length; j++) {
-                                    var label = response.results[j][0];
-                                    var value = response.results[j][1];
-                                    infos.push([label, value, idx++]);
-                                }
-// WEBANNO EXTENSION END - #1293 Display information via the brat "normalization" mechanism
-                                // sort, prioritizing images (to get floats right)
-                                infos = infos.sort(normInfoSortFunction);
-                                // generate HTML
-                                for (var i = 0; i < infos.length; i++) {
-                                    var label = infos[i][0];
-                                    var value = infos[i][1];
-                                    if (label && value) {
-                                        // special treatment for some label values
-                                        if (label.toLowerCase() == '<img>') {
-                                            // image
-                                            norminfo += ('<img class="norm_info_img" src="' + value + '"/>');
-                                        } else {
-                                            // normal, as text
-                                            // max length restriction
-                                            if (value.length > 300) {
-                                                value = value.substr(0, 300) + ' ...';
-                                            }
-
-                                            norminfo += ('<span class="norm_info_label">' + Util.escapeHTML(label) + '</span>' + '<span class="norm_info_value">' + ':' + Util.escapeHTML(value).replace(/\n/g, "<br/>") + '</span>' + '<br/>');
-                                        }
-                                    }
-                                }
-                                var drop = $('#norm_info_drop_point_' + infoSeqId);
-                                if (drop) {
-                                    drop.html(norminfo);
-                                } else {
-                                    console.log('norm info drop point not found!'); //TODO XXX
-                                }
-                            }
-                        }]);
-                    });
-                };
-
-            var displayArcComment = function(
-                evt, target, symmetric, arcId, originSpanId, originSpanType, role, targetSpanId, targetSpanType, commentText, commentType) {
-                    var arcRole = target.attr('data-arc-role');
-                    // in arrowStr, &#8212 == mdash, &#8594 == Unicode right arrow
-                    var arrowStr = symmetric ? '&#8212;' : '&#8594;';
-                    var arcDisplayForm = Util.arcDisplayForm(spanTypes, data.spans[originSpanId].type, arcRole, relationTypesHash);
-                    var comment = "";
-                    comment += ('<span class="comment_type_id_wrapper">' + '<span class="comment_type">' + Util.escapeHTML(Util.spanDisplayForm(spanTypes, originSpanType)) + ' ' + arrowStr + ' ' + Util.escapeHTML(arcDisplayForm) + ' ' + arrowStr + ' ' + Util.escapeHTML(Util.spanDisplayForm(spanTypes, targetSpanType)) + '</span>' + '<span class="comment_id">' + (arcId ? 'ID:' + arcId : Util.escapeHTML(originSpanId) + arrowStr + Util.escapeHTML(targetSpanId)) + '</span>' + '</span>');
-                    comment += ('<div class="comment_text">' + Util.escapeHTML('"' + data.spans[originSpanId].text + '"') + arrowStr + Util.escapeHTML('"' + data.spans[targetSpanId].text + '"') + '</div>');
-                    displayComment(evt, target, comment, commentText, commentType);
-                };
-
-            var displaySentComment = function(
-                evt, target, commentText, commentType) {
-                    displayComment(evt, target, '', commentText, commentType);
-                };
-
-            var hideComment = function() {
-                    clearTimeout(displayCommentTimer);
-                    if (commentDisplayed) {
-// BEGIN WEBANNO EXTENSION - #1610 - Improve brat visualization interaction performance
-// - Show/hide comments immediately instead of using an animation to avoid costly reflows
-/*
-                        commentPopup.stop(true, true).fadeOut(0, function() {
-                            commentDisplayed = false;
-                        });
-*/
-                        commentPopup.hide();
-                        commentDisplayed = false;
-// END WEBANNO EXTENSION - #1610 - Improve brat visualization interaction performance
-                    }
-                };
-
-            var onMouseMove = function(evt) {
-                    if (commentDisplayed) {
-                        adjustToCursor(evt, commentPopup, 10, true, true);
-                    }
-                };
-
-            /* END comment popup - related */
-
-
-            /* START form management - related */
-
-            initForm = function(form, opts) {
-                opts = opts || {};
-                var formId = form.attr('id');
-
-                // alsoResize is special
-                var alsoResize = opts.alsoResize;
-                delete opts.alsoResize;
-
-                // Always add OK and Cancel
-                var buttons = (opts.buttons || []);
-                if (opts.no_ok) {
-                    delete opts.no_ok;
                 } else {
-                    buttons.push({
-                        id: formId + "-ok",
-                        text: "OK",
-              			click: function() { form.submit(); }
-                    });
+                    // DB available, add drop-off point to HTML and store
+                    // query parameters
+                    var dbName = norm[0],
+                        dbKey = norm[1];
+                    commentPopupNormInfoSeqId++;
+                    comment += ('<hr/>' + '<span class="comment_id">' + Util.escapeHTML(dbName) + ':' + Util.escapeHTML(dbKey) + '</span>');
+                    comment += ('<br/><div id="norm_info_drop_point_' + commentPopupNormInfoSeqId + '"/>');
+                    normsToQuery.push([dbName, dbKey, commentPopupNormInfoSeqId]);
                 }
-                if (opts.no_cancel) {
-                    delete opts.no_cancel;
-                } else {
-                    buttons.push({
-                        id: formId + "-cancel",
-                        text: "Cancel",
-			            click: function() { form.dialog('close'); }
-                    });
-                }
-                delete opts.buttons;
-
-                opts = $.extend({
-                    autoOpen: false,
-                    closeOnEscape: true,
-                    buttons: buttons,
-                    modal: true
-                }, opts);
-			
-                form.dialog(opts);
-                form.bind('dialogclose', function() {
-                    if (form == currentForm) {
-                        currentForm = null;
-                    }
-                });
-
-                // HACK: jQuery UI's dialog does not support alsoResize
-                // nor does resizable support a jQuery object of several
-                // elements
-                // See: http://bugs.jqueryui.com/ticket/4666
-                if (alsoResize) {
-                    form.parent().resizable('option', 'alsoResize', '#' + form.attr('id') + ', ' + alsoResize);
-                }
-            };
-
-            var showForm = function(form) {
-                    currentForm = form;
-                    // as suggested in http://stackoverflow.com/questions/2657076/jquery-ui-dialog-fixed-positioning
-                    form.parent().css({
-                        position: "fixed"
-                    });
-                    form.dialog('open');
-                    slideToggle($('#pulldown').stop(), false);
-                    return form;
-                };
-
-            var hideForm = function() {
-                    if (!currentForm) return;
-                    // currentForm.fadeOut(function() { currentForm = null; });
-                    currentForm.dialog('close');
-                    currentForm = null;
-                };
-
-            var rememberNormDb = function(response) {
-                    // the visualizer needs to remember aspects of the norm setup
-                    // so that it can avoid making queries for unconfigured or
-                    // missing normalization DBs.
-                    var norm_resources = response.normalization_config || [];
-                    $.each(norm_resources, function(normNo, norm) {
-                        var normName = norm[0];
-                        var serverDb = norm[3];
-                        normServerDbByNormDbName[normName] = serverDb;
-                    });
-                }
-
-
-            var onKeyDown = function(evt) {
-                    var code = evt.which;
-
-                    if (code === $.ui.keyCode.ESCAPE) {
-                        dispatcher.post('messages', [false]);
-                        return;
-                    }
-
-                    if (currentForm) {
-                        if (code === $.ui.keyCode.ENTER) {
-                            // don't trigger submit in textareas to allow multiline text
-                            // entry
-                            // NOTE: spec seems to require this to be upper-case,
-                            // but at least chrome 8.0.552.215 returns lowercased
-                            var nodeType = evt.target.type ? evt.target.type.toLowerCase() : '';
-                            if (evt.target.nodeName && evt.target.nodeName.toLowerCase() == 'input' && (nodeType == 'text' || nodeType == 'password')) {
-                                currentForm.trigger('submit');
-                                return false;
-                            }
-                        } else if (evt.ctrlKey && (code == 'F'.charCodeAt(0) || code == 'G'.charCodeAt(0))) {
-                            // prevent Ctrl-F/Ctrl-G in forms
-                            evt.preventDefault();
-                            return false;
-                        }
-                        return;
-                    }
-
-                    if (code === $.ui.keyCode.TAB) {
-                        //  showFileBrowser();
-                        return false;
-                    } else if (code == $.ui.keyCode.LEFT) {
-                        //   return moveInFileBrowser(-1);
-                    } else if (code === $.ui.keyCode.RIGHT) {
-                        //   return moveInFileBrowser(+1);
-                    } else if (evt.shiftKey && code === $.ui.keyCode.UP) {
-                        //  autoPaging(true);
-                    } else if (evt.shiftKey && code === $.ui.keyCode.DOWN) {
-                        // autoPaging(false);
-                    } else if (evt.ctrlKey && code == 'F'.charCodeAt(0)) {
-                        // evt.preventDefault();
-                        // showSearchForm();
-                    } else if (searchActive && evt.ctrlKey && code == 'G'.charCodeAt(0)) {
-                        //  evt.preventDefault();
-                        //   return moveInFileBrowser(+1);
-                    } else if (searchActive && evt.ctrlKey && code == 'K'.charCodeAt(0)) {
-                        //  evt.preventDefault();
-                        //   clearSearchResults();
-                    }
-                };
-
-            var onDoneRendering = function(coll, doc, args) {
-                    if (args && !args.edited) {
-                        var $inFocus = $('#svg animate[data-type="focus"]:first').parent();
-                        if ($inFocus.length) {
-                            var svgtop = $('svg').offset().top;
-                            $('html,body').
-                            animate({ scrollTop: $inFocus.offset().top - svgtop - window.innerHeight / 2 }, { duration: 'slow', easing: 'swing'});
-                        }
-                    }
-                    dispatcher.post('allowReloadByURL');
-                    if (!currentForm) {
-                        $('#waiter').dialog('close');
-                    }
-                }
-
-            var onStartedRendering = function() {
-                    hideForm();
-                    if (!currentForm) {
-                        $('#waiter').dialog('open');
-                    }
-                }
-
-            var invalidateSavedSVG = function() {
-                    // assuming that invalidation of the SVG invalidates all stored
-                    // static visualizations, as others are derived from the SVG
-                    $('#download_stored').hide();
-                    // have a way to regenerate if dialog open when data invalidated
-                    $('#stored_file_regenerate').show();
-                    currentDocumentSVGsaved = false;
-                };
-
-            var slideToggle = function(el, show, autoHeight, bottom) {
-                    var el = $(el);
-                    var visible = el.is(":visible");
-                    var height;
-
-                    if (show === undefined) show = !visible;
-
-                    // @amadanmath: commenting this out appears to remove the annoying
-                    // misfeature where it's possible to stop the menu halfway by
-                    // mousing out and back in during closing. Please check that
-                    // this doesn't introduce other trouble and remove these lines.
-                    //         if (show === visible) return false;
-                    if (!autoHeight) {
-                        height = el.data("cachedHeight");
-                    } else {
-                        el.height('auto');
-                    }
-                    if (!height) {
-                        height = el.show().height();
-                        el.data('cachedHeight', height);
-          				if (!visible) el.hide().css({ height: 0 });
-                    }
-
-                    if (show) {
-          					el.show().animate({ height: height }, {
-                            duration: 150,
-                            complete: function() {
-                                if (autoHeight) {
-                                    el.height('auto');
-                                }
-                            },
-            				step: bottom ? function(now, fx) {
-                                fx.elem.scrollTop = fx.elem.scrollHeight;
-                            } : undefined
-                        });
-                    } else {
-          				el.animate({ height: 0 }, {
-                            duration: 300,
-                            complete: function() {
-                                el.hide();
-                            }
-                        });
-                    }
-                }
-
-                // TODO: copy from annotator_ui; DRY it up
-            var adjustFormToCursor = function(evt, element) {
-                    var screenHeight = $(window).height() - 8; // TODO HACK - no idea why -8 is needed
-                    var screenWidth = $(window).width() - 8;
-                    var elementHeight = element.height();
-                    var elementWidth = element.width();
-                    var y = Math.min(evt.clientY, screenHeight - elementHeight);
-                    var x = Math.min(evt.clientX, screenWidth - elementWidth);
-        			element.css({ top: y, left: x });
-                };
-            var viewspanForm = $('#viewspan_form');
-            var onDblClick = function(evt) {
-                    if (user && annotationAvailable) return;
-                    var target = $(evt.target);
-                    var id;
-                    if (id = target.attr('data-span-id')) {
-                        window.getSelection().removeAllRanges();
-                        var span = data.spans[id];
-
-                        var urlHash = URLHash.parse(window.location.hash);
-          				urlHash.setArgument('focus', [[span.id]]);
-                        $('#viewspan_highlight_link').show().attr('href', urlHash.getHash());
-
-                        $('#viewspan_selected').text(span.text);
-                        var encodedText = encodeURIComponent(span.text);
-                        $.each(searchConfig, function(searchNo, search) {
-                            $('#viewspan_' + search[0]).attr('href', search[1].replace('%s', encodedText));
-                        });
-                        // annotator comments
-                        $('#viewspan_notes').val(span.annotatorNotes || '');
-                        dispatcher.post('showForm', [viewspanForm]);
-                        $('#viewspan_form-ok').focus();
-                        adjustFormToCursor(evt, viewspanForm.parent());
-                    }
-                };
-            viewspanForm.submit(function(evt) {
-                dispatcher.post('hideForm');
-                return false;
+// WEBANNO EXTENSION END - #1293 Display information via the brat "normalization" mechanism
             });
 
-            var resizeFunction = function(evt) {
-// WEBANNO EXTENSION BEGIN - #1519 - Optimize re-rendering of brat view when window is resizes
-/*
-            	window.location.reload();
-*/
-            	dispatcher.post('rerender');
-// WEBANNO EXTENSION BEGIN - #1519 - Optimize re-rendering of brat view when window is resizes
-            };
+            // display initial comment HTML
+            displayComment(evt, target, comment, commentText, commentType, immediately);
 
-              var resizerTimeout = null;
-              var onResize = function(evt) {
-                if (evt.target === window) {
-                  clearTimeout(resizerTimeout);
-                  resizerTimeout = setTimeout(resizeFunction, 300);
+            // initiate AJAX calls for the normalization data to query
+            $.each(normsToQuery, function(normqNo, normq) {
+                // TODO: cache some number of most recent norm_get_data results
+                var dbName = normq[0],
+                    dbKey = normq[1],
+                    infoSeqId = normq[2];
+                dispatcher.post('ajax', [{
+                    action: 'normData',
+                    database: dbName,
+                    key: dbKey,
+                    collection: coll,
+// WEBANNO EXTENSION BEGIN - #1293 Display information via the brat "normalization" mechanism
+                    id: spanId,
+                    type: spanType,
+// WEBANNO EXTENSION END - #1293 Display information via the brat "normalization" mechanism
+                }, function(response) {
+                    if (response.exception) {; // TODO: response to error
+// WEBANNO EXTENSION BEGIN - #1293 Display information via the brat "normalization" mechanism
+                        /*
+                                                    } else if (!response.value) {; // TODO: response to missing key
+                        */
+                    } else if (!response.results) {; // TODO: response to missing key
+// WEBANNO EXTENSION END - #1293 Display information via the brat "normalization" mechanism
+                    } else {
+                        // extend comment popup with normalization data
+                        norminfo = '';
+                        // flatten outer (name, attr, info) array (idx for sort)
+                        infos = [];
+                        var idx = 0;
+// WEBANNO EXTENSION BEGIN - #1293 Display information via the brat "normalization" mechanism
+                        /*
+                                                        for (var i = 0; i < response.value.length; i++) {
+                                                            for (var j = 0; j < response.value[i].length; j++) {
+                                                                var label = response.value[i][j][0];
+                                                                var value = response.value[i][j][1];
+                                                                infos.push([label, value, idx++]);
+                                                            }
+                                                        }
+                        */
+                        for (var j = 0; j < response.results.length; j++) {
+                            var label = response.results[j][0];
+                            var value = response.results[j][1];
+                            infos.push([label, value, idx++]);
+                        }
+// WEBANNO EXTENSION END - #1293 Display information via the brat "normalization" mechanism
+                        // sort, prioritizing images (to get floats right)
+                        infos = infos.sort(normInfoSortFunction);
+                        // generate HTML
+                        for (var i = 0; i < infos.length; i++) {
+                            var label = infos[i][0];
+                            var value = infos[i][1];
+                            if (label && value) {
+                                // special treatment for some label values
+                                if (label.toLowerCase() == '<img>') {
+                                    // image
+                                    norminfo += ('<img class="norm_info_img" src="' + value + '"/>');
+                                } else {
+                                    // normal, as text
+                                    // max length restriction
+                                    if (value.length > 300) {
+                                        value = value.substr(0, 300) + ' ...';
+                                    }
+
+                                    norminfo += ('<span class="norm_info_label">' + Util.escapeHTML(label) + '</span>' + '<span class="norm_info_value">' + ':' + Util.escapeHTML(value).replace(/\n/g, "<br/>") + '</span>' + '<br/>');
+                                }
+                            }
+                        }
+                        var drop = $('#norm_info_drop_point_' + infoSeqId);
+                        if (drop) {
+                            drop.html(norminfo);
+                        } else {
+                            console.log('norm info drop point not found!'); //TODO XXX
+                        }
+                    }
+                }]);
+            });
+        };
+
+        var displayArcComment = function(
+            evt, target, symmetric, arcId, originSpanId, originSpanType, role, targetSpanId, targetSpanType, commentText, commentType) {
+            var arcRole = target.attr('data-arc-role');
+            // in arrowStr, &#8212 == mdash, &#8594 == Unicode right arrow
+            var arrowStr = symmetric ? '&#8212;' : '&#8594;';
+            var arcDisplayForm = Util.arcDisplayForm(spanTypes, data.spans[originSpanId].type, arcRole, relationTypesHash);
+            var comment = "";
+            comment += ('<span class="comment_type_id_wrapper">' + '<span class="comment_type">' + Util.escapeHTML(Util.spanDisplayForm(spanTypes, originSpanType)) + ' ' + arrowStr + ' ' + Util.escapeHTML(arcDisplayForm) + ' ' + arrowStr + ' ' + Util.escapeHTML(Util.spanDisplayForm(spanTypes, targetSpanType)) + '</span>' + '<span class="comment_id">' + (arcId ? 'ID:' + arcId : Util.escapeHTML(originSpanId) + arrowStr + Util.escapeHTML(targetSpanId)) + '</span>' + '</span>');
+            comment += ('<div class="comment_text">' + Util.escapeHTML('"' + data.spans[originSpanId].text + '"') + arrowStr + Util.escapeHTML('"' + data.spans[targetSpanId].text + '"') + '</div>');
+            console.log(comment)
+            displayComment(evt, target, comment, commentText, commentType);
+        };
+
+        var displaySentComment = function(
+            evt, target, commentText, commentType) {
+            displayComment(evt, target, '', commentText, commentType);
+        };
+
+        var hideComment = function() {
+
+
+
+            clearTimeout(displayCommentTimer);
+            if (commentDisplayed) {
+// BEGIN WEBANNO EXTENSION - #1610 - Improve brat visualization interaction performance
+// - Show/hide comments immediately instead of using an animation to avoid costly reflows
+                /*
+                                        commentPopup.stop(true, true).fadeOut(0, function() {
+                                            commentDisplayed = false;
+                                        });
+                */
+                $('.annotationpannel').css('display','none')
+                commentPopup.hide();
+                commentDisplayed = false;
+// END WEBANNO EXTENSION - #1610 - Improve brat visualization interaction performance
+            }
+        };
+
+        var onMouseMove = function(evt) {
+            if (commentDisplayed) {
+                adjustToCursor(evt, commentPopup, 10, true, true);
+            }
+        };
+
+        /* END comment popup - related */
+
+
+        /* START form management - related */
+
+        initForm = function(form, opts) {
+            opts = opts || {};
+            var formId = form.attr('id');
+
+            // alsoResize is special
+            var alsoResize = opts.alsoResize;
+            delete opts.alsoResize;
+
+            // Always add OK and Cancel
+            var buttons = (opts.buttons || []);
+            if (opts.no_ok) {
+                delete opts.no_ok;
+            } else {
+                buttons.push({
+                    id: formId + "-ok",
+                    text: "OK",
+                    click: function() { form.submit(); }
+                });
+            }
+            if (opts.no_cancel) {
+                delete opts.no_cancel;
+            } else {
+                buttons.push({
+                    id: formId + "-cancel",
+                    text: "Cancel",
+                    click: function() { form.dialog('close'); }
+                });
+            }
+            delete opts.buttons;
+
+            opts = $.extend({
+                autoOpen: false,
+                closeOnEscape: true,
+                buttons: buttons,
+                modal: true
+            }, opts);
+
+            form.dialog(opts);
+            form.bind('dialogclose', function() {
+                if (form == currentForm) {
+                    currentForm = null;
                 }
-              };
-              
+            });
+
+            // HACK: jQuery UI's dialog does not support alsoResize
+            // nor does resizable support a jQuery object of several
+            // elements
+            // See: http://bugs.jqueryui.com/ticket/4666
+            if (alsoResize) {
+                form.parent().resizable('option', 'alsoResize', '#' + form.attr('id') + ', ' + alsoResize);
+            }
+        };
+
+        var showForm = function(form) {
+            currentForm = form;
+            // as suggested in http://stackoverflow.com/questions/2657076/jquery-ui-dialog-fixed-positioning
+            form.parent().css({
+                position: "fixed"
+            });
+            form.dialog('open');
+            slideToggle($('#pulldown').stop(), false);
+            return form;
+        };
+
+        var hideForm = function() {
+            if (!currentForm) return;
+            // currentForm.fadeOut(function() { currentForm = null; });
+            currentForm.dialog('close');
+            currentForm = null;
+        };
+
+        var rememberNormDb = function(response) {
+            // the visualizer needs to remember aspects of the norm setup
+            // so that it can avoid making queries for unconfigured or
+            // missing normalization DBs.
+            var norm_resources = response.normalization_config || [];
+            $.each(norm_resources, function(normNo, norm) {
+                var normName = norm[0];
+                var serverDb = norm[3];
+                normServerDbByNormDbName[normName] = serverDb;
+            });
+        }
+
+
+        var onKeyDown = function(evt) {
+            var code = evt.which;
+
+            if (code === $.ui.keyCode.ESCAPE) {
+                dispatcher.post('messages', [false]);
+                return;
+            }
+
+            if (currentForm) {
+                if (code === $.ui.keyCode.ENTER) {
+                    // don't trigger submit in textareas to allow multiline text
+                    // entry
+                    // NOTE: spec seems to require this to be upper-case,
+                    // but at least chrome 8.0.552.215 returns lowercased
+                    var nodeType = evt.target.type ? evt.target.type.toLowerCase() : '';
+                    if (evt.target.nodeName && evt.target.nodeName.toLowerCase() == 'input' && (nodeType == 'text' || nodeType == 'password')) {
+                        currentForm.trigger('submit');
+                        return false;
+                    }
+                } else if (evt.ctrlKey && (code == 'F'.charCodeAt(0) || code == 'G'.charCodeAt(0))) {
+                    // prevent Ctrl-F/Ctrl-G in forms
+                    evt.preventDefault();
+                    return false;
+                }
+                return;
+            }
+
+            if (code === $.ui.keyCode.TAB) {
+                //  showFileBrowser();
+                return false;
+            } else if (code == $.ui.keyCode.LEFT) {
+                //   return moveInFileBrowser(-1);
+            } else if (code === $.ui.keyCode.RIGHT) {
+                //   return moveInFileBrowser(+1);
+            } else if (evt.shiftKey && code === $.ui.keyCode.UP) {
+                //  autoPaging(true);
+            } else if (evt.shiftKey && code === $.ui.keyCode.DOWN) {
+                // autoPaging(false);
+            } else if (evt.ctrlKey && code == 'F'.charCodeAt(0)) {
+                // evt.preventDefault();
+                // showSearchForm();
+            } else if (searchActive && evt.ctrlKey && code == 'G'.charCodeAt(0)) {
+                //  evt.preventDefault();
+                //   return moveInFileBrowser(+1);
+            } else if (searchActive && evt.ctrlKey && code == 'K'.charCodeAt(0)) {
+                //  evt.preventDefault();
+                //   clearSearchResults();
+            }
+        };
+
+        var onDoneRendering = function(coll, doc, args) {
+            if (args && !args.edited) {
+                var $inFocus = $('#svg animate[data-type="focus"]:first').parent();
+                if ($inFocus.length) {
+                    var svgtop = $('svg').offset().top;
+                    $('html,body').
+                    animate({ scrollTop: $inFocus.offset().top - svgtop - window.innerHeight / 2 }, { duration: 'slow', easing: 'swing'});
+                }
+            }
+            dispatcher.post('allowReloadByURL');
+            if (!currentForm) {
+                $('#waiter').dialog('close');
+            }
+        }
+
+        var onStartedRendering = function() {
+            hideForm();
+            if (!currentForm) {
+                $('#waiter').dialog('open');
+            }
+        }
+
+        var invalidateSavedSVG = function() {
+            // assuming that invalidation of the SVG invalidates all stored
+            // static visualizations, as others are derived from the SVG
+            $('#download_stored').hide();
+            // have a way to regenerate if dialog open when data invalidated
+            $('#stored_file_regenerate').show();
+            currentDocumentSVGsaved = false;
+        };
+
+        var slideToggle = function(el, show, autoHeight, bottom) {
+            var el = $(el);
+            var visible = el.is(":visible");
+            var height;
+
+            if (show === undefined) show = !visible;
+
+            // @amadanmath: commenting this out appears to remove the annoying
+            // misfeature where it's possible to stop the menu halfway by
+            // mousing out and back in during closing. Please check that
+            // this doesn't introduce other trouble and remove these lines.
+            //         if (show === visible) return false;
+            if (!autoHeight) {
+                height = el.data("cachedHeight");
+            } else {
+                el.height('auto');
+            }
+            if (!height) {
+                height = el.show().height();
+                el.data('cachedHeight', height);
+                if (!visible) el.hide().css({ height: 0 });
+            }
+
+            if (show) {
+                el.show().animate({ height: height }, {
+                    duration: 150,
+                    complete: function() {
+                        if (autoHeight) {
+                            el.height('auto');
+                        }
+                    },
+                    step: bottom ? function(now, fx) {
+                        fx.elem.scrollTop = fx.elem.scrollHeight;
+                    } : undefined
+                });
+            } else {
+                el.animate({ height: 0 }, {
+                    duration: 300,
+                    complete: function() {
+                        el.hide();
+                    }
+                });
+            }
+        }
+
+        // TODO: copy from annotator_ui; DRY it up
+        var adjustFormToCursor = function(evt, element) {
+            var screenHeight = $(window).height() - 8; // TODO HACK - no idea why -8 is needed
+            var screenWidth = $(window).width() - 8;
+            var elementHeight = element.height();
+            var elementWidth = element.width();
+            var y = Math.min(evt.clientY, screenHeight - elementHeight);
+            var x = Math.min(evt.clientX, screenWidth - elementWidth);
+            element.css({ top: y, left: x });
+        };
+        var viewspanForm = $('#viewspan_form');
+        var onDblClick = function(evt) {
+            if (user && annotationAvailable) return;
+            var target = $(evt.target);
+            var id;
+            if (id = target.attr('data-span-id')) {
+                window.getSelection().removeAllRanges();
+                var span = data.spans[id];
+
+                var urlHash = URLHash.parse(window.location.hash);
+                urlHash.setArgument('focus', [[span.id]]);
+                $('#viewspan_highlight_link').show().attr('href', urlHash.getHash());
+
+                $('#viewspan_selected').text(span.text);
+                var encodedText = encodeURIComponent(span.text);
+                $.each(searchConfig, function(searchNo, search) {
+                    $('#viewspan_' + search[0]).attr('href', search[1].replace('%s', encodedText));
+                });
+                // annotator comments
+                $('#viewspan_notes').val(span.annotatorNotes || '');
+                dispatcher.post('showForm', [viewspanForm]);
+                $('#viewspan_form-ok').focus();
+                adjustFormToCursor(evt, viewspanForm.parent());
+            }
+        };
+        viewspanForm.submit(function(evt) {
+            dispatcher.post('hideForm');
+            return false;
+        });
+
+        var resizeFunction = function(evt) {
+// WEBANNO EXTENSION BEGIN - #1519 - Optimize re-rendering of brat view when window is resizes
+            /*
+                            window.location.reload();
+            */
+            dispatcher.post('rerender');
+// WEBANNO EXTENSION BEGIN - #1519 - Optimize re-rendering of brat view when window is resizes
+        };
+
+        var resizerTimeout = null;
+        var onResize = function(evt) {
+            if (evt.target === window) {
+                clearTimeout(resizerTimeout);
+                resizerTimeout = setTimeout(resizeFunction, 300);
+            }
+        };
+
 // WEBANNO EXTENSION BEGIN
 // Sending the whoami and getting the user is mandatory because many things in brat will not work
 // unless it believes that the user has logged in.
 // WEBANNO EXTENSION END
-      var init = function() {
+        var init = function() {
 // WEBANNO EXTENSION BEGIN
-/*
-        dispatcher.post('initForm', [viewspanForm, {
-            width: 760,
-            no_cancel: true
-          }]);
-        dispatcher.post('ajax', [{
-            action: 'whoami'
-          }, function(response) {
-            var auth_button = $('#auth_button');
-            if (response.user) {
-              user = response.user;
-              dispatcher.post('messages', [[['Welcome back, user "' + user + '"', 'comment']]]);
-              auth_button.val('Logout ' + user);
-              dispatcher.post('user', [user]);
-              $('.login').show();
-            } else {
-              user = null;
-              auth_button.val('Login');
-              dispatcher.post('user', [null]);
-              $('.login').hide();
-              // don't show tutorial if there's a specific document (annoyance)
-              if (!doc) {
-                dispatcher.post('showForm', [tutorialForm]);
-                $('#tutorial-ok').focus();
-              }
-            }
-          },
-          { keep: true }
-        ]);
-*/
-        // Need to set a  user because many things in brat will not work otherwise
-        user = "dummy";
-        dispatcher.post('user', [user]);
+            /*
+                    dispatcher.post('initForm', [viewspanForm, {
+                        width: 760,
+                        no_cancel: true
+                      }]);
+                    dispatcher.post('ajax', [{
+                        action: 'whoami'
+                      }, function(response) {
+                        var auth_button = $('#auth_button');
+                        if (response.user) {
+                          user = response.user;
+                          dispatcher.post('messages', [[['Welcome back, user "' + user + '"', 'comment']]]);
+                          auth_button.val('Logout ' + user);
+                          dispatcher.post('user', [user]);
+                          $('.login').show();
+                        } else {
+                          user = null;
+                          auth_button.val('Login');
+                          dispatcher.post('user', [null]);
+                          $('.login').hide();
+                          // don't show tutorial if there's a specific document (annoyance)
+                          if (!doc) {
+                            dispatcher.post('showForm', [tutorialForm]);
+                            $('#tutorial-ok').focus();
+                          }
+                        }
+                      },
+                      { keep: true }
+                    ]);
+            */
+            // Need to set a  user because many things in brat will not work otherwise
+            user = "dummy";
+            dispatcher.post('user', [user]);
 // WEBANNO EXTENSION END
 // WEBANNO EXTENSION BEGIN
 // /*
-        dispatcher.post('ajax', [{ action: 'loadConf' }, function(response) {
-          if (response.config != undefined) {
+            dispatcher.post('ajax', [{ action: 'loadConf' }, function(response) {
+                if (response.config != undefined) {
 // WEBANNO EXTENSION BEGIN
 // WebAnno sends the configuration as a proper JSON object - no need to parse it
-/*
-            // TODO: check for exceptions
-            try {
-              Configuration = JSON.parse(response.config);
-            } catch(x) {
-              // XXX Bad config
-              Configuration = {};
-              dispatcher.post('messages', [[['Corrupted configuration; resetting.', 'error']]]);
-              configurationChanged();
+                    /*
+                                // TODO: check for exceptions
+                                try {
+                                  Configuration = JSON.parse(response.config);
+                                } catch(x) {
+                                  // XXX Bad config
+                                  Configuration = {};
+                                  dispatcher.post('messages', [[['Corrupted configuration; resetting.', 'error']]]);
+                                  configurationChanged();
+                                }
+                    */
+                    Configuration = response.config;
+// WEBANNO EXTENSION END
+                    // TODO: make whole-object assignment work
+                    // @amadanmath: help! This code is horrible
+                    // Configuration.svgWidth = storedConf.svgWidth;
+                    dispatcher.post('svgWidth', [Configuration.svgWidth]);
+                    // Configuration.abbrevsOn = storedConf.abbrevsOn == "true";
+                    // Configuration.textBackgrounds = storedConf.textBackgrounds;
+                    // Configuration.rapidModeOn = storedConf.rapidModeOn == "true";
+                    // Configuration.confirmModeOn = storedConf.confirmModeOn == "true";
+                    // Configuration.autorefreshOn = storedConf.autorefreshOn == "true";
+                    if (Configuration.autorefreshOn) {
+                        checkForDocumentChanges();
+                    }
+                    // Configuration.visual.margin.x = parseInt(storedConf.visual.margin.x);
+                    // Configuration.visual.margin.y = parseInt(storedConf.visual.margin.y);
+                    // Configuration.visual.boxSpacing = parseInt(storedConf.visual.boxSpacing);
+                    // Configuration.visual.curlyHeight = parseInt(storedConf.visual.curlyHeight);
+                    // Configuration.visual.arcSpacing = parseInt(storedConf.visual.arcSpacing);
+                    // Configuration.visual.arcStartHeight = parseInt(storedConf.visual.arcStartHeight);
+                }
+                dispatcher.post('configurationUpdated');
+            }]);
+        };
+// WEBANNO EXTENSION BEGIN
+        /*
+              var noFileSpecified = function() {
+                // not (only) an error, so no messaging
+                dispatcher.post('clearSVG');
+                showFileBrowser();
+              }
+
+              var showUnableToReadTextFile = function() {
+                dispatcher.post('messages', [[['Unable to read the text file.', 'error']]]);
+                dispatcher.post('clearSVG');
+                showFileBrowser();
+              };
+
+              var showAnnotationFileNotFound = function() {
+                dispatcher.post('messages', [[['Annotation file not found.', 'error']]]);
+                dispatcher.post('clearSVG');
+                showFileBrowser();
+              };
+
+              var showUnknownError = function(exception) {
+                dispatcher.post('messages', [[['Unknown error: ' + exception, 'error']]]);
+                dispatcher.post('clearSVG');
+                showFileBrowser();
+              };
+
+              var reloadDirectoryWithSlash = function(sourceData) {
+                var collection = sourceData.collection + sourceData.document + '/';
+                dispatcher.post('setCollection', [collection, '', sourceData.arguments]);
+              };
+
+              // TODO: confirm attributeTypes unnecessary and remove
+        //       var spanAndAttributeTypesLoaded = function(_spanTypes, _attributeTypes) {
+        //         spanTypes = _spanTypes;
+        //         attributeTypes = _attributeTypes;
+        //       };
+              // TODO: spanAndAttributeTypesLoaded is obviously not descriptive of
+              // the full function. Rename reasonably.
+        */
+// WEBANNO EXTENSION END
+
+        var spanAndAttributeTypesLoaded = function(_spanTypes, _entityAttributeTypes, _eventAttributeTypes, _relationTypesHash) {
+            spanTypes = _spanTypes;
+            relationTypesHash = _relationTypesHash;
+        };
+
+        var annotationIsAvailable = function() {
+            annotationAvailable = true;
+        };
+
+
+        var isReloadOkay = function() {
+            // do not reload while the user is in the dialog
+            return currentForm == null;
+        };
+
+        var configurationChanged = function() {
+            // just assume that any config change makes stored
+            // visualizations invalid. This is a bit excessive (not all
+            // options affect visualization) but mostly harmless.
+            invalidateSavedSVG();
+
+            // save configuration changed by user action
+            dispatcher.post('ajax', [{
+                action: 'saveConf',
+                config: JSON.stringify(Configuration),
+            }, null]);
+        };
+
+// WEBANNO EXTENSION BEGIN
+        /*
+              var updateConfigurationUI = function() {
+                // update UI to reflect non-user config changes (e.g. load)
+
+                // Annotation mode
+                if (Configuration.confirmModeOn) {
+                  $('#annotation_speed1')[0].checked = true;
+                } else if (Configuration.rapidModeOn) {
+                  $('#annotation_speed3')[0].checked = true;
+                } else {
+                  $('#annotation_speed2')[0].checked = true;
+                }
+                $('#annotation_speed input').button('refresh');
+
+                // Label abbrevs
+                $('#label_abbreviations_on')[0].checked  = Configuration.abbrevsOn;
+                $('#label_abbreviations_off')[0].checked = !Configuration.abbrevsOn;
+                $('#label_abbreviations input').button('refresh');
+
+                // Text backgrounds
+                $('#text_backgrounds input[value="'+Configuration.textBackgrounds+'"]')[0].checked = true;
+                $('#text_backgrounds input').button('refresh');
+
+                // SVG width
+                var splitSvgWidth = Configuration.svgWidth.match(/^(.*?)(px|\%)$/);
+                if (!splitSvgWidth) {
+                  // TODO: reset to sensible value?
+                  dispatcher.post('messages', [[['Error parsing SVG width "'+Configuration.svgWidth+'"', 'error', 2]]]);
+                } else {
+                  $('#svg_width_value')[0].value = splitSvgWidth[1];
+                  $('#svg_width_unit input[value="'+splitSvgWidth[2]+'"]')[0].checked = true;
+                  $('#svg_width_unit input').button('refresh');
+                }
+
+                // Autorefresh
+                $('#autorefresh_mode')[0].checked = Configuration.autorefreshOn;
+                $('#autorefresh_mode').button('refresh');
+
+                // Type Collapse Limit
+                $('#type_collapse_limit')[0].value = Configuration.typeCollapseLimit;
+              }
+
+              $('#prev').button().click(function() {
+                return moveInFileBrowser(-1);
+              });
+              $('#next').button().click(function() {
+                return moveInFileBrowser(+1);
+              });
+              $('#footer').show();
+
+              $('#source_collection_conf_on, #source_collection_conf_off').change(function() {
+                var conf = $('#source_collection_conf_on').is(':checked') ? 1 : 0;
+                var $source_collection_link = $('#source_collection a');
+                var link = $source_collection_link.attr('href').replace(/&include_conf=./, '&include_conf=' + conf);
+                $source_collection_link.attr('href', link);
+              });
+        */
+// WEBANNO EXTENSION END
+
+        var rememberData = function(_data) {
+            if (_data && !_data.exception) {
+                data = _data;
             }
-*/
-            Configuration = response.config;
+        };
+
+// WEBANNO EXTENSION BEGIN
+        /*
+              var onScreamingHalt = function() {
+                $('#waiter').dialog('close');
+                $('#pulldown, #navbuttons, #spinner').remove();
+                dispatcher.post('hideForm');
+              };
+        */
 // WEBANNO EXTENSION END
-            // TODO: make whole-object assignment work
-            // @amadanmath: help! This code is horrible
-            // Configuration.svgWidth = storedConf.svgWidth;
-            dispatcher.post('svgWidth', [Configuration.svgWidth]);
-            // Configuration.abbrevsOn = storedConf.abbrevsOn == "true";
-            // Configuration.textBackgrounds = storedConf.textBackgrounds;
-            // Configuration.rapidModeOn = storedConf.rapidModeOn == "true";
-            // Configuration.confirmModeOn = storedConf.confirmModeOn == "true";
-            // Configuration.autorefreshOn = storedConf.autorefreshOn == "true";
-            if (Configuration.autorefreshOn) {
-              checkForDocumentChanges();
+
+// WEBANNO EXTENSION BEGIN
+        var contextMenu = function(evt) {
+            // If the user shift-right-clicks, open the normal browser context menu. This is useful
+            // e.g. during debugging / developing
+            if (evt.shiftKey) {
+                return;
             }
-            // Configuration.visual.margin.x = parseInt(storedConf.visual.margin.x);
-            // Configuration.visual.margin.y = parseInt(storedConf.visual.margin.y);
-            // Configuration.visual.boxSpacing = parseInt(storedConf.visual.boxSpacing);
-            // Configuration.visual.curlyHeight = parseInt(storedConf.visual.curlyHeight);
-            // Configuration.visual.arcSpacing = parseInt(storedConf.visual.arcSpacing);
-            // Configuration.visual.arcStartHeight = parseInt(storedConf.visual.arcStartHeight);
-          }
-          dispatcher.post('configurationUpdated');
-        }]);
-      };
-// WEBANNO EXTENSION BEGIN
-/*
-      var noFileSpecified = function() {
-        // not (only) an error, so no messaging
-        dispatcher.post('clearSVG');
-        showFileBrowser();
-      }
 
-      var showUnableToReadTextFile = function() {
-        dispatcher.post('messages', [[['Unable to read the text file.', 'error']]]);
-        dispatcher.post('clearSVG');
-        showFileBrowser();
-      };
+            var target = $(evt.target);
+            var id;
+            var type;
 
-      var showAnnotationFileNotFound = function() {
-        dispatcher.post('messages', [[['Annotation file not found.', 'error']]]);
-        dispatcher.post('clearSVG');
-        showFileBrowser();
-      };
+            if (target.attr('data-arc-ed')) {
+                id = target.attr('data-arc-ed');
+                type = target.attr('data-arc-role');
+            }
 
-      var showUnknownError = function(exception) {
-        dispatcher.post('messages', [[['Unknown error: ' + exception, 'error']]]);
-        dispatcher.post('clearSVG');
-        showFileBrowser();
-      };
+            if (target.attr('data-span-id')) {
+                id = target.attr('data-span-id');
+                type = data.spans[id].type;
+            }
 
-      var reloadDirectoryWithSlash = function(sourceData) {
-        var collection = sourceData.collection + sourceData.document + '/';
-        dispatcher.post('setCollection', [collection, '', sourceData.arguments]);
-      };
-
-      // TODO: confirm attributeTypes unnecessary and remove
-//       var spanAndAttributeTypesLoaded = function(_spanTypes, _attributeTypes) {
-//         spanTypes = _spanTypes;
-//         attributeTypes = _attributeTypes;
-//       };
-      // TODO: spanAndAttributeTypesLoaded is obviously not descriptive of
-      // the full function. Rename reasonably.
-*/
-// WEBANNO EXTENSION END
-
-      var spanAndAttributeTypesLoaded = function(_spanTypes, _entityAttributeTypes, _eventAttributeTypes, _relationTypesHash) {
-        spanTypes = _spanTypes;
-        relationTypesHash = _relationTypesHash;
-      };
-
-      var annotationIsAvailable = function() {
-        annotationAvailable = true;
-      };
-
-
-      var isReloadOkay = function() {
-        // do not reload while the user is in the dialog
-        return currentForm == null;
-      };
-
-      var configurationChanged = function() {
-        // just assume that any config change makes stored
-        // visualizations invalid. This is a bit excessive (not all
-        // options affect visualization) but mostly harmless.
-        invalidateSavedSVG();
-
-        // save configuration changed by user action
-        dispatcher.post('ajax', [{
-                    action: 'saveConf',
-                    config: JSON.stringify(Configuration),
-                }, null]);
-      };
-
-// WEBANNO EXTENSION BEGIN
-/*
-      var updateConfigurationUI = function() {
-        // update UI to reflect non-user config changes (e.g. load)
-        
-        // Annotation mode
-        if (Configuration.confirmModeOn) {
-          $('#annotation_speed1')[0].checked = true;
-        } else if (Configuration.rapidModeOn) {
-          $('#annotation_speed3')[0].checked = true;
-        } else {
-          $('#annotation_speed2')[0].checked = true;
+            if (id) {
+                evt.preventDefault();
+                dispatcher.post('ajax', [ {
+                    action: 'contextMenu',
+                    id: id,
+                    type: type,
+                    clientX: evt.clientX,
+                    clientY: evt.clientY
+                }, 'serverResult']);
+            }
         }
-        $('#annotation_speed input').button('refresh');
-
-        // Label abbrevs
-        $('#label_abbreviations_on')[0].checked  = Configuration.abbrevsOn;
-        $('#label_abbreviations_off')[0].checked = !Configuration.abbrevsOn; 
-        $('#label_abbreviations input').button('refresh');
-
-        // Text backgrounds        
-        $('#text_backgrounds input[value="'+Configuration.textBackgrounds+'"]')[0].checked = true;
-        $('#text_backgrounds input').button('refresh');
-
-        // SVG width
-        var splitSvgWidth = Configuration.svgWidth.match(/^(.*?)(px|\%)$/);
-        if (!splitSvgWidth) {
-          // TODO: reset to sensible value?
-          dispatcher.post('messages', [[['Error parsing SVG width "'+Configuration.svgWidth+'"', 'error', 2]]]);
-        } else {
-          $('#svg_width_value')[0].value = splitSvgWidth[1];
-          $('#svg_width_unit input[value="'+splitSvgWidth[2]+'"]')[0].checked = true;
-          $('#svg_width_unit input').button('refresh');
-        }
-
-        // Autorefresh
-        $('#autorefresh_mode')[0].checked = Configuration.autorefreshOn;
-        $('#autorefresh_mode').button('refresh');
-
-        // Type Collapse Limit
-        $('#type_collapse_limit')[0].value = Configuration.typeCollapseLimit;
-      }
-
-      $('#prev').button().click(function() {
-        return moveInFileBrowser(-1);
-      });
-      $('#next').button().click(function() {
-        return moveInFileBrowser(+1);
-      });
-      $('#footer').show();
-
-      $('#source_collection_conf_on, #source_collection_conf_off').change(function() {
-        var conf = $('#source_collection_conf_on').is(':checked') ? 1 : 0;
-        var $source_collection_link = $('#source_collection a');
-        var link = $source_collection_link.attr('href').replace(/&include_conf=./, '&include_conf=' + conf);
-        $source_collection_link.attr('href', link);
-      });
-*/
 // WEBANNO EXTENSION END
 
-      var rememberData = function(_data) {
-        if (_data && !_data.exception) {
-          data = _data;
-        }
-      };
-      
-// WEBANNO EXTENSION BEGIN
-/*
-      var onScreamingHalt = function() {
-        $('#waiter').dialog('close');
-        $('#pulldown, #navbuttons, #spinner').remove();
-        dispatcher.post('hideForm');
-      };
-*/
-// WEBANNO EXTENSION END
 
+        dispatcher.
+        on('init', init).
+        on('dataReady', rememberData).
+        on('annotationIsAvailable', annotationIsAvailable).
+            // WEBANNO EXTENSION BEGIN
+            /*
+                      on('messages', displayMessages).
+            */
+            // WEBANNO EXTENSION END
+            on('displaySpanComment', displaySpanComment).
+        on('displayArcComment', displayArcComment).
+        on('displaySentComment', displaySentComment).
+            // WEBANNO EXTENSION BEGIN
+            /*
+                      on('docChanged', onDocChanged).
+            */
+            // WEBANNO EXTENSION END
+            on('hideComment', hideComment).
+            // WEBANNO EXTENSION BEGIN
+            /*
+                      on('showForm', showForm).
+                      on('hideForm', hideForm).
+                      on('initForm', initForm).
+            */
+            // WEBANNO EXTENSION END
+            on('resize', onResize).
+        on('collectionLoaded', rememberNormDb).
+            // WEBANNO EXTENSION BEGIN
+            /*
+                      on('collectionLoaded', collectionLoaded).
+            */
+            // WEBANNO EXTENSION END
+            on('spanAndAttributeTypesLoaded', spanAndAttributeTypesLoaded).
+        on('isReloadOkay', isReloadOkay).
+            // WEBANNO EXTENSION BEGIN
+            /*
+                      on('current', gotCurrent).
+            */
+            // WEBANNO EXTENSION END
+            on('doneRendering', onDoneRendering).
+        on('startedRendering', onStartedRendering).
+            // WEBANNO EXTENSION BEGIN
+            /*
+                      on('newSourceData', onNewSourceData).
+                      on('savedSVG', savedSVGreceived).
+                      on('renderError:noFileSpecified', noFileSpecified).
+                      on('renderError:annotationFileNotFound', showAnnotationFileNotFound).
+                      on('renderError:unableToReadTextFile', showUnableToReadTextFile).
+                      on('renderError:isDirectoryError', reloadDirectoryWithSlash).
+                      on('unknownError', showUnknownError).
+            */
+            // WEBANNO EXTENSION END
+            on('keydown', onKeyDown).
+        on('mousemove', onMouseMove).
+        on('contextmenu', contextMenu);
 // WEBANNO EXTENSION BEGIN
-      var contextMenu = function(evt) {
-        // If the user shift-right-clicks, open the normal browser context menu. This is useful
-        // e.g. during debugging / developing
-        if (evt.shiftKey) {
-          return;
-        }
-  
-        var target = $(evt.target);
-        var id;
-        var type;
-        
-        if (target.attr('data-arc-ed')) {
-          id = target.attr('data-arc-ed');
-          type = target.attr('data-arc-role');
-        }
-  
-        if (target.attr('data-span-id')) {
-          id = target.attr('data-span-id');
-          type = data.spans[id].type;
-        }
-  
-        if (id) {
-          evt.preventDefault();
-          dispatcher.post('ajax', [ {
-            action: 'contextMenu',
-            id: id,
-            type: type,
-            clientX: evt.clientX,
-            clientY: evt.clientY
-          }, 'serverResult']);
-        }
-      }
-// WEBANNO EXTENSION END
-      
-      
-      dispatcher.
-          on('init', init).
-          on('dataReady', rememberData).
-          on('annotationIsAvailable', annotationIsAvailable).
-// WEBANNO EXTENSION BEGIN
-/*
-          on('messages', displayMessages).
-*/
-// WEBANNO EXTENSION END
-          on('displaySpanComment', displaySpanComment).
-          on('displayArcComment', displayArcComment).
-          on('displaySentComment', displaySentComment).
-// WEBANNO EXTENSION BEGIN
-/*
-          on('docChanged', onDocChanged).
-*/
-// WEBANNO EXTENSION END
-          on('hideComment', hideComment).
-// WEBANNO EXTENSION BEGIN
-/*
-          on('showForm', showForm).
-          on('hideForm', hideForm).
-          on('initForm', initForm).
-*/
-// WEBANNO EXTENSION END
-          on('resize', onResize).
-          on('collectionLoaded', rememberNormDb).
-// WEBANNO EXTENSION BEGIN
-/*
-          on('collectionLoaded', collectionLoaded).
-*/
-// WEBANNO EXTENSION END
-          on('spanAndAttributeTypesLoaded', spanAndAttributeTypesLoaded).
-          on('isReloadOkay', isReloadOkay).
-// WEBANNO EXTENSION BEGIN
-/*
-          on('current', gotCurrent).
-*/
-// WEBANNO EXTENSION END
-          on('doneRendering', onDoneRendering).
-          on('startedRendering', onStartedRendering).
-// WEBANNO EXTENSION BEGIN
-/*
-          on('newSourceData', onNewSourceData).
-          on('savedSVG', savedSVGreceived).
-          on('renderError:noFileSpecified', noFileSpecified).
-          on('renderError:annotationFileNotFound', showAnnotationFileNotFound).
-          on('renderError:unableToReadTextFile', showUnableToReadTextFile).
-          on('renderError:isDirectoryError', reloadDirectoryWithSlash).
-          on('unknownError', showUnknownError).
-*/
-// WEBANNO EXTENSION END
-          on('keydown', onKeyDown).
-          on('mousemove', onMouseMove).
-          on('contextmenu', contextMenu);
-// WEBANNO EXTENSION BEGIN
-/*
-          on('dblclick', onDblClick).
-          on('touchstart', onTouchStart).
-          on('touchend', onTouchEnd).
-          on('resize', onResize).
-          on('searchResultsReceived', searchResultsReceived).
-          on('clearSearch', clearSearch).
-          on('clearSVG', showNoDocMessage).
-          on('screamingHalt', onScreamingHalt).
-          on('configurationChanged', configurationChanged).
-          on('configurationUpdated', updateConfigurationUI);
-*/
+        /*
+                  on('dblclick', onDblClick).
+                  on('touchstart', onTouchStart).
+                  on('touchend', onTouchEnd).
+                  on('resize', onResize).
+                  on('searchResultsReceived', searchResultsReceived).
+                  on('clearSearch', clearSearch).
+                  on('clearSVG', showNoDocMessage).
+                  on('screamingHalt', onScreamingHalt).
+                  on('configurationChanged', configurationChanged).
+                  on('configurationUpdated', updateConfigurationUI);
+        */
 // WEBANNO EXTENSION END
     };
-    
+
     return VisualizerUI;
 })(jQuery, window);

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.html
@@ -17,28 +17,29 @@
   limitations under the License.
 -->
 <html xmlns:wicket="http://wicket.apache.org">
+
 <body>
-  <wicket:extend>
-    <div class="flex-content flex-v-container">
-      <div class="annotation-editor-container flex-content flex-h-container flex-gutter flex-no-initial-gutter">
-        <div wicket:id="leftSidebar" class="flex-sidebar flex-v-container flex-gutter"></div>
-        <div wicket:id="centerArea" class="flex-content flex-v-container flex-gutter">
-          <div class="flex-content card">
-            <div class="card-header border-bottom-0">
-              <span wicket:id="documentNamePanel"/> 
-              <span wicket:id="numberOfPages" class="small text-muted float-right"/>
-            </div>
-            <div class="card-body flex-v-container" style="padding: 0px;">
-              <nav wicket:id="actionBar" class="action-bar"/>
-              <div wicket:id="editor" class="flex-content flex-v-container" style="padding: 0px;"/>
-            </div>
+<wicket:extend>
+  <div class="flex-content flex-v-container">
+    <div class="annotation-editor-container flex-content flex-h-container flex-gutter flex-no-initial-gutter">
+      <div wicket:id="leftSidebar" class="flex-sidebar flex-v-container flex-gutter"></div>
+      <div wicket:id="centerArea" class="flex-content flex-v-container flex-gutter">
+        <div class="flex-content card">
+          <div class="card-header border-bottom-0">
+            <span wicket:id="documentNamePanel"/>
+            <span wicket:id="numberOfPages" class="small text-muted float-right"/>
           </div>
-        </div>
-        <div wicket:id="rightSidebar" class="flex-sidebar flex-v-container">
-          <wicket:container wicket:id="annotationDetailEditorPanel"/>
+          <div class="card-body flex-v-container" style="padding: 0px;">
+            <nav wicket:id="actionBar" class="action-bar"/>
+            <div wicket:id="editor" class="flex-content flex-v-container" style="padding: 0px;"/>
+          </div>
         </div>
       </div>
     </div>
-  </wicket:extend>
+  </div>
+  <div wicket:id="rightSidebar" class="annotationpannel" >
+    <wicket:container wicket:id="annotationDetailEditorPanel"/>
+  </div>
+</wicket:extend>
 </body>
 </html>

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
@@ -18,96 +18,99 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <head>
-<wicket:head>
-  <script type="text/javascript">
-  $(document).ready(function() {
-    // Based on this accepted answer of so
-    // http://stackoverflow.com/questions/2335553/jquery-how-to-catch-enter-key-and-change-event-to-tab
-    
-    function moveToNextInput(current) {
-      var inputs = $(current).parents("#annotationFeatureForm").eq(0).find(":input");
-      var idx = inputs.index(current);
-      if (idx == inputs.length - 1) {
-        inputs[idx].blur();
-      } else {
-        inputs[idx + 1].focus(); //  handles submit buttons
-        inputs[idx + 1].select();
-      }
-      // If it is a forward annotation on free text, trigger change even on Enter key up
-      if($('#annotationFeatureForm :checkbox:checked').length > 0) {
-        $(this).trigger("change")
-      }
-    }
-    
-    function manageEnter() {
-      $("#annotationFeatureForm :input").keydown(function(e) {
-        if (e.which == 13) {
-          // On a textarea, we consider the enter as a submit only if CTRL or CMD is pressed
-          if ($(this).is("textarea") && !(e.ctrlKey || e.metaKey)) {
-            return true;
+  <wicket:head>
+    <script type="text/javascript">
+      $(document).ready(function() {
+        // Based on this accepted answer of so
+        // http://stackoverflow.com/questions/2335553/jquery-how-to-catch-enter-key-and-change-event-to-tab
+
+        function moveToNextInput(current) {
+          var inputs = $(current).parents("#annotationFeatureForm").eq(0).find(":input");
+          var idx = inputs.index(current);
+          if (idx == inputs.length - 1) {
+            inputs[idx].blur();
+          } else {
+            inputs[idx + 1].focus(); //  handles submit buttons
+            inputs[idx + 1].select();
           }
-          
-          // Avoid Kendo Comboboxes submitting their value twice
-          if ($(this).attr('role') == 'combobox') {
-            return true;
+          // If it is a forward annotation on free text, trigger change even on Enter key up
+          if($('#annotationFeatureForm :checkbox:checked').length > 0) {
+            $(this).trigger("change")
           }
-      
-          e.preventDefault();
-          moveToNextInput(this);
-          return false;
         }
-      });    
-    }
-    $(document).on("keypress", manageEnter);
-    manageEnter();
-  });
-  </script>
-</wicket:head>
+
+        function manageEnter() {
+          $("#annotationFeatureForm :input").keydown(function(e) {
+            if (e.which == 13) {
+              // On a textarea, we consider the enter as a submit only if CTRL or CMD is pressed
+              if ($(this).is("textarea") && !(e.ctrlKey || e.metaKey)) {
+                return true;
+              }
+
+              // Avoid Kendo Comboboxes submitting their value twice
+              if ($(this).attr('role') == 'combobox') {
+                return true;
+              }
+
+              e.preventDefault();
+              moveToNextInput(this);
+              return false;
+            }
+          });
+        }
+        $(document).on("keypress", manageEnter);
+        manageEnter();
+      });
+    </script>
+  </wicket:head>
 </head>
 <body>
-  <wicket:panel>
-    <div id="annotationDetailEditorPanel" class="flex-content flex-v-container">
-      <!-- 
-        Style the form such that it is actionable by keyboard events but does not take up space
-        on the screen.
-       -->
+<wicket:panel>
+  <div id="annotationDetailEditorPanel" class="editorpannel" >
+    <!--
+      Style the form such that it is actionable by keyboard events but does not take up space
+      on the screen.
+     -->
+
+    <div id="annotationFeatureForm" class="annotatation-detail-panel flex-content flex-v-container flex-gutter">
+
       <form wicket:id="forwardForm" style="width: 1px; height: 1px; overflow: hidden; opacity: 0; margin-top: -1px;">
-        <!-- 
+        <!--
           The user should never tab into this field accidentally. Focus is set explicitly by the
           forward annotation mode.
          -->
         <input wicket:id=forwardAnno tabindex="-1"></input>
       </form>
-      <div id="annotationFeatureForm" class="annotatation-detail-panel flex-content flex-v-container flex-gutter">
-        <div wicket:id=deleteAnnotationDialog/>
+
+      <div wicket:id=deleteAnnotationDialog/>
         <div wicket:id=replaceAnnotationDialog/>
-        <div wicket:id="layerContainer" class="card"/>
-        <div class="flex-content panel card">
-          <div class="card-header">
-            Annotation
-            <div wicket:id="buttonContainer" class="actions">
-              <button wicket:id="delete" class="btn btn-danger" wicket:message="title:delete">
-                <i class="fas fa-trash"></i>
-                <span class="d-none d-xl-inline">&nbsp;<wicket:message key="delete"/></span>
-              </button>
-              <button wicket:id="reverse" class="btn btn-secondary" wicket:message="title:reverse">
-                <i class="fas fa-arrows-alt-h"></i>
-                <span class="d-none d-xl-inline">&nbsp;<wicket:message key="reverse"/></span>
-              </button>
-              <button wicket:id="clear" class="btn btn-secondary" wicket:message="title:clear">
-                <i class="fas fa-times"></i>
-                <span class="d-none d-xl-inline">&nbsp;<wicket:message key="clear"/></span>
-              </button>
+          <div wicket:id="layerContainer" class="card layercard"/>
+          <div class="flex-content panel card annotationcard">
+            <div class="card-header">
+              Annotation
+              <div wicket:id="buttonContainer" class="actions">
+                <button wicket:id="delete" class="btn btn-danger" wicket:message="title:delete">
+                  <i class="fas fa-trash"></i>
+                  <span class="d-none d-xl-inline">&nbsp;<wicket:message key="delete"/></span>
+                </button>
+                <button wicket:id="reverse" class="btn btn-secondary" wicket:message="title:reverse">
+                  <i class="fas fa-arrows-alt-h"></i>
+                  <span class="d-none d-xl-inline">&nbsp;<wicket:message key="reverse"/></span>
+                </button>
+                <button wicket:id="clear" class="btn btn-secondary" wicket:message="title:clear">
+                  <i class="fas fa-times"></i>
+                  <span class="d-none d-xl-inline">&nbsp;<wicket:message key="clear"/></span>
+                </button>
+              </div>
             </div>
-          </div>
-          <div class="scrolling card-body flex-v-container">
-            <div wicket:id="infoContainer"/>
-            <div wicket:id="relationListContainer"/>
-            <div wicket:id="featureEditorContainer"/>
+            <div class="card-body flex-v-container">
+              <div wicket:id="infoContainer"/>
+              <div wicket:id="relationListContainer"/>
+              <div wicket:id="featureEditorContainer"/>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </wicket:panel>
+</wicket:panel>
 </body>
 </html>

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AttachedAnnotationListPanel.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AttachedAnnotationListPanel.html
@@ -18,23 +18,23 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
-  <wicket:panel>
-    <div wicket:id="noAttachedAnnotationsInfo" class="flex-content flex-h-container text-center small text-muted mb-2">
-      <div>No links or relations connect to this annotation.</div>
-    </div>
-    <div class="flex-content feature-editors-sidebar" wicket:id="attachedAnnotationsContainer">
-      <div class="form-group form-row" wicket:id="annotations">
-        <label class="feature-editor-label col-form-label">
-          <a wicket:id="selectRelation"><i wicket:id="direction" aria-hidden="true"/></a>
-          <span wicket:id="label"/>
-          <a wicket:id="jumpToEndpoint" class="float-right"><i class="fas fa-crosshairs"></i></a>
-        </label>
-        <div class="feature-editor-value">
-          <div wicket:id="endpoint" class="form-control col-sm-12 scrolling"
-            style="height: unset; max-height: 4.5rem; word-wrap: break-word;" readonly></div>
-        </div>
+<wicket:panel>
+  <div wicket:id="noAttachedAnnotationsInfo" class="flex-content flex-h-container text-center small text-muted mb-2">
+    <div>No links or relations connect to this annotation.</div>
+  </div>
+  <div class="flex-content feature-editors-sidebar" wicket:id="attachedAnnotationsContainer">
+    <div class="form-group form-row" wicket:id="annotations">
+      <label class="feature-editor-label col-form-label">
+        <a wicket:id="selectRelation"><i wicket:id="direction" aria-hidden="true"/></a>
+        <span wicket:id="label"/>
+        <a wicket:id="jumpToEndpoint" class="float-right"><i class="fas fa-crosshairs"></i></a>
+      </label>
+      <div class="feature-editor-value">
+        <div wicket:id="endpoint" class="form-control col-sm-12 scrolling annotationtagvalue"
+             style="height: unset; max-height: 4.5rem; word-wrap: break-word;" readonly></div>
       </div>
     </div>
-  </wicket:panel>
+  </div>
+</wicket:panel>
 </body>
 </html>

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/webanno-custom.scss
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/webanno-custom.scss
@@ -17,7 +17,7 @@
  */
 
 html, body {
-//  font-family: 'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif;
+  //  font-family: 'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif;
   min-height: 100%;
   max-height: 100%;
   height: 100%;
@@ -40,22 +40,22 @@ html, body {
 
 .page-footer {
   flex: none;
-  min-height: $page-footer-height; 
+  min-height: $page-footer-height;
   height: $page-footer-height;
   overflow: hidden;
-  margin-top: 0px; 
-  margin-bottom: 0px; 
-  text-align: center; 
-  font-size: $font-size-sm; 
+  margin-top: 0px;
+  margin-bottom: 0px;
+  text-align: center;
+  font-size: $font-size-sm;
   padding-left: ceil(($grid-gutter-width / 2));
   padding-right: floor(($grid-gutter-width / 2));
   color: $card-color;
   background-color: $card-bg;
   border-color: $card-border-color;
   border-top: 1px solid;
-  
+
   a, a:hover, a:focus {
-  	color: black;
+    color: black;
   }
 }
 
@@ -66,7 +66,7 @@ html, body {
   min-width: 30%;
   max-height: calc(100vh - $page-footer-height - $page-header-height);
   overflow: auto;
- 
+
   ul.feedbackPanel {
     list-style:none;
   }
@@ -75,7 +75,7 @@ html, body {
     padding-top: 5px;
     padding-bottom: 5px;
     margin-bottom: 10px;
-  }  
+  }
 }
 
 .nav-pills img {
@@ -113,7 +113,7 @@ span.form-control {
 .w_flex .w_content_container > div { height: 100%; }
 .w_flex .w_flex_container { display: flex; flex-direction: column; height: 100%; }
 .w_flex .w_flex_content { flex: 1; overflow: auto; padding-top: 15px; padding-bottom: 15px; }
-.w_flex .w_flex_footer { flex: none; } 
+.w_flex .w_flex_footer { flex: none; }
 
 
 .min-content-height {
@@ -181,24 +181,25 @@ span.form-control {
 
 /* style for the warning popover in the page footer */
 .dev-warnings {
-	.alert {
-	  padding: 0px 5px 0px 5px;
-	  border: none;
-	  color: yellow;
-	  background-color: red;
-	}
-	
- .popover-content ul {
+  .alert {
+    padding: 0px 5px 0px 5px;
+    border: none;
+    color: yellow;
+    background-color: red;
+  }
+
+  .popover-content ul {
     padding-left: 18px;
   }
-  
+
   a, a:hover, a:focus {
-	  color: yellow;
+    color: yellow;
   }
 }
 
 /* Fixes to brat CSS */
 #commentpopup {
+  display: none;
   text-align: initial;
 }
 
@@ -210,49 +211,49 @@ a.disabled {
 
 
 .no-data-notice {
-	@extend .text-muted;
-	background-color: $card-cap-bg;
+  @extend .text-muted;
+  background-color: $card-cap-bg;
   display: flex;
-  justify-content: center; 
+  justify-content: center;
   align-items: center;
-	min-height: 5rem;
-	text-align: center;
+  min-height: 5rem;
+  text-align: center;
 }
 
 .card-body {
-	.no-data-notice {
-		margin: -$card-spacer-x;
-		padding: $card-spacer-x;
-	}
+  .no-data-notice {
+    margin: -$card-spacer-x;
+    padding: $card-spacer-x;
+  }
 }
 
 
 // Make the JQuery context menu fit in nicely with the rest of the theme instead of showing up in
 // bright orange
 .ui-menu {
-	text-align: left;
-	
-	.ui-menu-item {
-		.ui-menu-item-wrapper.ui-state-active {
-			color: $component-active-color;
-			background-color: $component-active-bg;
-			background-image: none;
-		}
-	}
+  text-align: left;
+
+  .ui-menu-item {
+    .ui-menu-item-wrapper.ui-state-active {
+      color: $component-active-color;
+      background-color: $component-active-bg;
+      background-image: none;
+    }
+  }
 }
 
 .context-menu {
-	z-index: 999;
+  z-index: 999;
 }
 
 // A class for something that needs to be there in order to get events but should not actually be
 // visible to the user (i.e. use no space)
 .there-but-not-visible {
-	width: 1px; 
-	height: 1px; 
-	overflow: hidden; 
-	opacity: 0; 
-	margin-top: -1px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+  margin-top: -1px;
 }
 
 /* -------------------------------------------------------------------------------------------------
@@ -260,7 +261,7 @@ a.disabled {
  */
 
 label.required {
-    color: red;
+  color: red;
 }
 
 /* -------------------------------------------------------------------------------------------------
@@ -279,11 +280,11 @@ label.required {
  * Menu
  */
 .locationbar {
-    text-align: left; 
-    /*color: maroon;*/
-    padding-left: 1em;
-    padding-right: 1em;
-    margin-top: 0.2em;
+  text-align: left;
+  /*color: maroon;*/
+  padding-left: 1em;
+  padding-right: 1em;
+  margin-top: 0.2em;
 }
 
 /* -------------------------------------------------------------------------------------------------
@@ -292,29 +293,29 @@ label.required {
 
 /* Use for a horizontal list of icons */
 ul.horizontal{
-    margin:0px;
-    padding:0px;
+  margin:0px;
+  padding:0px;
 }
 
 ul.horizontal li{
-    margin-left:0.5em;
-    margin-right:0.5em;
-    display:inline-block;
-    text-align:center;
+  margin-left:0.5em;
+  margin-right:0.5em;
+  display:inline-block;
+  text-align:center;
 }
 
 a.menulink {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 a.menulink > span {
   font-size: 120%;
-    text-decoration: none;
-    color: white;
-    display: table-cell;
-    vertical-align: middle;
-    padding-left: 1em;
-    padding-right: 1em;
+  text-decoration: none;
+  color: white;
+  display: table-cell;
+  vertical-align: middle;
+  padding-left: 1em;
+  padding-right: 1em;
 }
 
 /* -------------------------------------------------------------------------------------------------
@@ -322,57 +323,57 @@ a.menulink > span {
  */
 
 th{
-    padding:3px;
+  padding:3px;
 }
 
 tr.odd{
-    background:#EEEEEE;
+  background:#EEEEEE;
 }
 
 tr.even{
-    background:#DDDDDD;
+  background:#DDDDDD;
 }
 
 tr.odd:hover{
-    background:#CCCCAA;
+  background:#CCCCAA;
 }
 
 tr.even:hover{
-    background:#CCCCAA;
+  background:#CCCCAA;
 }
 
 .headers,
 .headers a:link,
 .headers a:visited{
-    background-color:#B90F22;
-    color:white;
-    vertical-align:bottom;
+  background-color:#B90F22;
+  color:white;
+  vertical-align:bottom;
 }
 
 tr.headers th.wicket_orderDown a::after {
-    font-family: "Font Awesome 5 Free";
-    content: "\f0dd";
-    display: inline-block;
-    padding-left: 3px;
-    vertical-align: middle;
-    font-weight: 900;
+  font-family: "Font Awesome 5 Free";
+  content: "\f0dd";
+  display: inline-block;
+  padding-left: 3px;
+  vertical-align: middle;
+  font-weight: 900;
 }
 
 tr.headers th.wicket_orderUp a::after {
-    font-family: "Font Awesome 5 Free";
-    content: "\f0de";
-    display: inline-block;
-    padding-left: 3px;
-    vertical-align: middle;
-    font-weight: 900;
+  font-family: "Font Awesome 5 Free";
+  content: "\f0de";
+  display: inline-block;
+  padding-left: 3px;
+  vertical-align: middle;
+  font-weight: 900;
 }
 
 div.navigatorLabel{
-    float:left;
+  float:left;
 }
 
 div.navigator{
-    text-align:right;
+  text-align:right;
 }
 
 /* -------------------------------------------------------------------------------------------------
@@ -383,11 +384,11 @@ div.left-tabpanel {
 }
 
 div.left-tabpanel div.tab-row {
-	flex: none;
+  flex: none;
   width: 39px;
-	background-color: #f5f5f5;
-	border: 1px solid #ddd;  
-	
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+
   display: flex;
   flex-direction: column;
 }
@@ -410,28 +411,28 @@ div.left-tabpanel div.tab-row li {
 }
 
 div.left-tabpanel div.tab-row li img {
-    display: block;
-    padding: 3px;
+  display: block;
+  padding: 3px;
 }
 
 div.left-tabpanel div.tab-row a:link,
 div.left-tabpanel div.tab-row a:visited {
-    display: block;
-    background:#f3f3f3;
-    padding: 0px;
-    margin: 0px;
-    text-decoration:none;
-    color:#666;
+  display: block;
+  background:#f3f3f3;
+  padding: 0px;
+  margin: 0px;
+  text-decoration:none;
+  color:#666;
 }
 
 div.left-tabpanel div.tab-row li.selected a:link,
 div.left-tabpanel div.tab-row a:visited.active {
-    background:#fff;
-    color:#000;
+  background:#fff;
+  color:#000;
 }
 
 div.left-tabpanel div.tab-row a:hover {
-    background:#fff;
+  background:#fff;
 }
 
 /* Remove left border from panel so it attaches nicely to the sidebar controls */
@@ -440,4 +441,24 @@ div.left-tabpanel div.tab-row a:hover {
   border-top-left-radius: 0px;
   border-bottom-left-radius:  0px;
   border-left: none;
+}
+.annotationpannel{
+  display: none;
+  position: absolute;
+}
+.editorpannel{
+  display: flex;
+}
+.layercard{
+  width: fit-content;
+  z-index: 10;
+}
+.layercard label{
+  min-width: min-content;
+}
+.layercard .col-sm-9{
+  max-width: max-content;
+}
+.annotationcard{
+  max-width: fit-content;
 }


### PR DESCRIPTION
Changing the annotation detail placement
The annotation bar is placed in the right corner, and all annotations are present directly above the words. The annotating process would be speed up if the bar was closer to the hover. We can access the annotation easier and fast. 
Remove the annotation panel from the right corner of the annotation screen and make the pannel visible whenever the mouse is moved over the annotation. The pannel can be made visible near the annotation. However, the annotation pannel updates only when a double-clicked operation is performed on the annotation. If the mouse is dragged to perform a selection for annotating, the pannel will not be visible to the user, The pannel gets visible when the new annotation is hovered. When the document is opened for the first time, the pannel is empty hence the double click operation must be performed to update the pannel.