### PR TITLE
Reset/recreate default admin account

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
@@ -101,14 +101,27 @@ public class LoginPage
         // Create admin user if there is no user yet
         if (userRepository.list().isEmpty()) {
             User admin = new User();
-            admin.setUsername(ADMIN_DEFAULT_USERNAME);
-            admin.setPassword(ADMIN_DEFAULT_PASSWORD);
+            if(System.getenv("WEBANNO_ENV_ADMIN_NAME")!=null){
+                admin.setUsername(System.getenv("WEBANNO_ENV_ADMIN_NAME"));
+            }
+            else {
+                admin.setUsername(ADMIN_DEFAULT_USERNAME);
+            }
+            //F1- default password from env
+            if(System.getenv("WEBANNO_ENV_ADMIN_PASS") != null){
+                admin.setPassword(System.getenv("WEBANNO_ENV_ADMIN_PASS"));
+            }else{
+                admin.setPassword(ADMIN_DEFAULT_PASSWORD);
+            }
             admin.setEnabled(true);
             admin.setRoles(EnumSet.of(Role.ROLE_ADMIN, Role.ROLE_USER));
             userRepository.create(admin);
-
             String msg = "No user accounts have been found. An admin account has been created: "
                     + ADMIN_DEFAULT_USERNAME + "/" + ADMIN_DEFAULT_PASSWORD;
+            if(System.getenv("WEBANNO_ENV_ADMIN_PASS") != null&&System.getenv("WEBANNO_ENV_ADMIN_NAME") != null){
+                msg = "No user accounts have been found. An admin account has been created: "
+                        +  System.getenv("WEBANNO_ENV_ADMIN_NAME") + "/" + System.getenv("WEBANNO_ENV_ADMIN_PASS");
+            }
             // We log this as a warning so the message sticks on the screen. Success and info
             // messages are set to auto-close after a short time.
             warn(msg);


### PR DESCRIPTION
Reset/ Recreate the default admin account.
The current version of webanno software creates a default admin account when there are no users account found. When the software runs for the first time, there will not be any user accounts, Hence to allow the user to access the software, webanno creates a default admin account with the username as admin and password as admin. We have to provide the liberty to the user to create his default admin account.
To allow the user to create his default admin account, we provide two environment variables. One of the environment variables contains the default username and the other default password(WEBANNO_ENV_ADMIN_NAME, WEBANNO_ENV_ADMIN_PASS). If these variables are present, then these values are considered to create the default admin account. If the values are not present, the default admin account is created with username as "admin" and password as "admin".