### PR TITLE
Allow file renaming in Project settings under documents tab

### DIFF
--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -494,7 +494,27 @@ public class DocumentServiceImpl
                     aDocument.getId(), project.getName(), project.getId());
         }
     }
+    @Override
+    @Transactional
+    public void renameSourceDocument(SourceDocument aDocument, String name) throws IOException
+    {
+        Validate.notNull(aDocument, "Source document must be specified");
+        Validate.notNull(name, "New name of the document should be specified");
 
+        File documentUri = new File(repositoryProperties.getPath().getAbsolutePath() + "/"
+                + PROJECT_FOLDER + "/" + aDocument.getProject().getId() + "/" + DOCUMENT_FOLDER
+                + "/" + aDocument.getId() + "/" + SOURCE_FOLDER);
+
+        File sourceDocFile = new File(documentUri, aDocument.getName());
+
+        entityManager.createQuery("UPDATE SourceDocument SET name = :name WHERE id = :docid AND project.id = : pid").setParameter("name", name)
+                .setParameter("docid", aDocument.getId())
+                .setParameter("pid", aDocument.getProject().getId())
+                .executeUpdate();
+
+        sourceDocFile.renameTo(name);
+        return ;
+    }
     @Override
     @Transactional
     public void removeAnnotationDocument(AnnotationDocument aAnnotationDocument)

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
@@ -138,6 +138,20 @@ public interface DocumentService
     void removeSourceDocument(SourceDocument document) throws IOException;
 
     /**
+     * ROLE_ADMINs or project admins can rename source documnents from a project. renaming a source
+     * document doesn't rename an annotation document related to that source document
+     *
+     * @param document
+     *          the source document to be renamed
+     * @param name
+     *          the rename of the document
+     * @throws IOException
+     *          If the source document searched for rename is not available
+     */
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_USER', 'ROLE_REMOTE')")
+    void renameSourceDocument(SourceDocument document, String name ) throws IOException;
+
+    /**
      * Upload a SourceDocument, obtained as Inputstream, such as from remote API Zip folder to a
      * repository directory. This way we don't need to create the file to a temporary folder
      *

--- a/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/dialog/RenameConfirmationDialog$ContentPanel.html
+++ b/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/dialog/RenameConfirmationDialog$ContentPanel.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+<wicket:panel>
+  <form wicket:id="form" class="w_flex_container">
+    <div class="w_flex_content">
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-sm-12">
+            <p>
+              <wicket:container wicket:id="content" />
+            </p>
+            <div>
+              <input wicket:id="response" class="form-control"/>
+            </div>
+            <p>
+              <span wicket:id="feedback"></span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="w_flex_footer card-footer">
+      <div class="form-group text-right">
+        <button wicket:id="confirm" class="btn btn-danger">
+          <i class="fas fa-check"></i>&nbsp;
+          <wicket:message key="confirm.label"/>
+        </button>
+        <button wicket:id="cancel" class="btn btn-secondary">
+          <i class="fas fa-times"></i>&nbsp;
+          <wicket:message key="cancel.label"/>
+        </button>
+      </div>
+    </div>
+  </form>
+</wicket:panel>
+</body>
+</html>

--- a/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/dialog/RenameConfirmationDialog.java
+++ b/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/dialog/RenameConfirmationDialog.java
@@ -1,0 +1,228 @@
+package de.tudarmstadt.ukp.clarin.webanno.support.dialog;
+
+import java.io.Serializable;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
+import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.panel.FeedbackPanel;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.slf4j.LoggerFactory;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.AjaxCallback;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.AjaxPayloadCallback;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+
+public class RenameConfirmationDialog
+        extends ModalWindow
+{
+    private static final long serialVersionUID = 5194857538069045172L;
+
+    private IModel<String> titleModel;
+    private IModel<String> contentModel;
+
+    private AjaxPayloadCallback<String> confirmAction;
+    private AjaxCallback cancelAction;
+
+    private ContentPanel contentPanel;
+
+    public RenameConfirmationDialog(String aId)
+    {
+        this(aId, null, null, null);
+        titleModel = new StringResourceModel("title", this, null);
+        contentModel = new StringResourceModel("text", this, null);
+    }
+    public RenameConfirmationDialog(String aId, IModel<String> aTitle)
+    {
+        this(aId, aTitle, Model.of());
+    }
+
+    public RenameConfirmationDialog(String aId, IModel<String> aTitle, IModel<String> aContent)
+    {
+        super(aId);
+
+        titleModel = aTitle;
+        contentModel = aContent;
+
+        setOutputMarkupId(true);
+        setInitialWidth(620);
+        setInitialHeight(440);
+        setResizable(true);
+        setWidthUnit("px");
+        setHeightUnit("px");
+        setCssClassName("w_blue w_flex");
+        showUnloadConfirmation(false);
+
+        setModel(new CompoundPropertyModel<>(null));
+
+        setContent(contentPanel = new ContentPanel(getContentId(), getModel()));
+
+        setCloseButtonCallback((_target) -> {
+            onCancelInternal(_target);
+            return true;
+        });
+    }
+
+    public void setModel(IModel<State> aModel)
+    {
+        setDefaultModel(aModel);
+    }
+
+    @SuppressWarnings("unchecked")
+    public IModel<State> getModel()
+    {
+        return (IModel<State>) getDefaultModel();
+    }
+
+    public void setModelObject(State aModel)
+    {
+        setDefaultModelObject(aModel);
+    }
+
+    public State getModelObject()
+    {
+        return (State) getDefaultModelObject();
+    }
+
+    public IModel<String> getTitleModel()
+    {
+        return titleModel;
+    }
+
+    public void setTitleModel(IModel<String> aTitleModel)
+    {
+        titleModel = aTitleModel;
+    }
+
+    public IModel<String> getContentModel()
+    {
+        return contentModel;
+    }
+
+    public void setContentModel(IModel<String> aContentModel)
+    {
+        contentModel = aContentModel;
+    }
+
+    @Override
+    public void show(IPartialPageRequestHandler aTarget)
+    {
+        contentModel.detach();
+
+        State state = new State();
+        state.content = contentModel.getObject();
+        state.response = null;
+        state.feedback = null;
+        setModelObject(state);
+
+        setTitle(titleModel.getObject());
+
+        super.show(aTarget);
+    }
+
+    public AjaxPaylodCallback<String> getConfirmAction()
+    {
+        return confirmAction;
+    }
+
+    public void setConfirmAction(AjaxPaylodCallback<String> aConfirmAction)
+    {
+        confirmAction = aConfirmAction;
+    }
+
+    public AjaxCallback getCancelAction()
+    {
+        return cancelAction;
+    }
+
+    public void setCancelAction(AjaxCallback aCancelAction)
+    {
+        cancelAction = aCancelAction;
+    }
+
+    protected void onConfirmInternal(AjaxRequestTarget aTarget, Form<State> aForm)
+    {
+        State state = aForm.getModelObject();
+
+        if(state.response == null){
+            state.feedback = "Should not be empty.";
+            atarget.add(aForm);
+            return;
+        }
+
+        boolean closeOk = true;
+
+        // Invoke callback if one is defined
+        if (confirmAction != null) {
+            try {
+                confirmAction.accept(aTarget, state.response);
+            }
+            catch (Exception e) {
+                LoggerFactory.getLogger(getPage().getClass()).error("Error: " + e.getMessage(), e);
+                state.feedback = "Error: " + e.getMessage();
+                aTarget.add(aForm);
+                closeOk = false;
+            }
+        }
+
+        if (closeOk) {
+            close(aTarget);
+        }
+    }
+
+
+    protected void onCancelInternal(AjaxRequestTarget aTarget)
+    {
+        if (cancelAction != null) {
+            try {
+                cancelAction.accept(aTarget);
+            }
+            catch (Exception e) {
+                LoggerFactory.getLogger(getPage().getClass()).error("Error: " + e.getMessage(), e);
+                contentPanel.form.getModelObject().feedback = "Error: " + e.getMessage();
+            }
+        }
+        close(aTarget);
+    }
+
+    private class State
+            implements Serializable
+    {
+        private static final long serialVersionUID = 4483229579553569947L;
+
+        private String content;
+        private String response;
+        private String feedback;
+    }
+
+    private class ContentPanel
+            extends Panel
+    {
+        private static final long serialVersionUID = 5202661827792148838L;
+
+        private FeedbackPanel feedbackPanel;
+        private Form<State> form;
+
+        public ContentPanel(String aId, IModel<State> aModel)
+        {
+            super(aId, aModel);
+
+            form = new Form<>("form", aModel);
+            form.add(new Label("content").setEscapeModelStrings(false));
+            form.add(new Label("feedback"));
+            form.add(new TextField<>("response"));
+            form.add(new LambdaAjaxButton<>("confirm",
+                    RenameConfirmationDialog.this::onConfirmInternal));
+            form.add(new LambdaAjaxLink("cancel", RenameConfirmationDialog.this::onCancelInternal));
+
+            add(form);
+        }
+    }
+}

--- a/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/dialog/RenameConfirmationDialog.properties
+++ b/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/dialog/RenameConfirmationDialog.properties
@@ -1,0 +1,2 @@
+confirm.label=Confirm
+cancel.label=Cancel

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/DocumentListPanel.html
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/DocumentListPanel.html
@@ -25,6 +25,10 @@
         <select wicket:id="documents" class="form-control"></select>
       </div>
       <div class="card-footer text-right">
+        <button wicket:id="rename" class=".btn-info">
+          <i class="far fa-edit"></i>&nbsp;
+          <wicket:message key="rename"/>
+        </button>
         <button wicket:id="delete" class="btn btn-danger">
           <i class="fas fa-trash"></i>&nbsp;
           <wicket:message key="delete"/>

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/ProjectDocumentsPanel.properties
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/ProjectDocumentsPanel.properties
@@ -1,7 +1,7 @@
-# Licensed to the Technische Universität Darmstadt under one
+# Licensed to the Technische Universitï¿½t Darmstadt under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
-# regarding copyright ownership.  The Technische Universität Darmstadt 
+# regarding copyright ownership.  The Technische Universitï¿½t Darmstadt 
 # licenses this file to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.
@@ -15,3 +15,5 @@
 # limitations under the License.
 DeleteDialog.title=Confirmation
 DeleteDialog.text=Are you sure you want to <b>delete {0}</b> document(s)?
+RenameDialog.title=Rename Confirmation
+RenameDialog.text=Are you sure you want to Rename document?


### PR DESCRIPTION
FEATURE:
Allow renaming the files in the document tab.
Explanation:
As a user, I would like to edit the file name in Project Settings. This feature allows the user to rename the file after importing it to the Projects under documents. To implement the above feature we found the code locations that have an impact on developing the feature. Then we started writing the code for the backend and coded the frontend part at last.
