### PR TITLE
Remote api via API token

### DIFF
--- a/webanno-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/token/GetUserToken.java
+++ b/webanno-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/token/GetUserToken.java
@@ -1,0 +1,78 @@
+package de.tudarmstadt.ukp.clarin.webanno.security.session;
+
+
+
+
+import org.slf4j.Logger;
+
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.context.ApplicationEvent;
+
+import org.springframework.context.event.EventListener;
+
+import org.springframework.core.Ordered;
+
+import org.springframework.core.annotation.Order;
+
+import org.springframework.security.core.Authentication;
+
+import org.springframework.security.core.context.SecurityContext;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import org.springframework.security.core.session.SessionRegistry;
+
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
+
+import org.springframework.security.web.session.HttpSessionCreatedEvent;
+
+import org.springframework.security.web.session.HttpSessionDestroyedEvent;
+
+import org.springframework.stereotype.Component;
+
+
+
+
+@Component
+
+public class GetUserToken
+
+{
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+
+
+
+    public String getToken()
+
+    {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if(authentication == null) {
+
+            log.trace("User Not logged In");
+
+            return 'No Token';
+
+        }
+
+
+
+
+        OAuth2AuthenticationDetails details = (OAuth2AuthenticationDetails) authentication.getDetails();
+
+        String accessToken = details.getTokenValue();
+
+
+
+
+        return accessToken;
+
+    }
+
+} 


### PR DESCRIPTION
FEATURE:
Allow remote API via API token.
EXPLANATION:
As a user, I want to use an API token instead of a username and password for better security. To access the webanno software one has to login by entering their username and password. An api token is used instead for more security. To implement this feature we found three interlinked locations and made some changes to enable this feature.