### PR TITLE
Annotation viewer mode

### DIFF
--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/LayerSelectionPanel.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/LayerSelectionPanel.html
@@ -43,6 +43,16 @@
           </div>
         </div>
       </div>
+       <div class="form-group and row" wicket:id="AnnotationUserViewer">
+        <div class="col-sm-13">
+          <div class="form-tick">
+            <input wicket:id="AnnotationUser" class="form-tick-input" type="checkbox"/>
+            <label wicket:for="AnnotationUser" class="form-tick-label">
+              Make visible to all
+            </label>
+          </div>
+        </div>
+      </div>
     </div>
   </wicket:panel>
 </body>


### PR DESCRIPTION
in this pull request, we implemented the feature for Annotation viewer mode. When the feature is enable by ticking the box, it makes the annotation visible to other managers.

As we looked into the feature (Annotation viewer mode), And have found out that the functionality has already been implemented, like the fact that annotations can be viewed by managers. We hit a pause as we discovered that the dialog folder is missing from the source code we were given. This limited our implementation.