### PR TITLE
Deprecated code##3

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -281,7 +281,7 @@ public abstract class WicketApplicationBase
 
     protected void initShowExceptionPage()
     {
-        Properties settings = SettingsUtil.getSettings();
+        Properties settings = SettingsUtil.get_Settings();
         if ("true".equalsIgnoreCase(settings.getProperty("debug.showExceptionPage"))) {
             getExceptionSettings()
                     .setUnexpectedExceptionDisplay(ExceptionSettings.SHOW_EXCEPTION_PAGE);
@@ -290,7 +290,7 @@ public abstract class WicketApplicationBase
 
     protected void initLogoReference()
     {
-        Properties settings = SettingsUtil.getSettings();
+        Properties settings = SettingsUtil.get_Settings();
         String logoValue = settings.getProperty(SettingsUtil.CFG_STYLE_LOGO);
         if (StringUtils.isNotBlank(logoValue) && new File(logoValue).canRead()) {
             getSharedResources().add("logo", new FileSystemResource(new File(logoValue)));
@@ -348,7 +348,7 @@ public abstract class WicketApplicationBase
 
     protected void initServerTimeReporting()
     {
-        Properties settings = SettingsUtil.getSettings();
+        Properties settings = SettingsUtil.get_Settings();
         if (!DEVELOPMENT.equals(getConfigurationType())
                 && !"true".equalsIgnoreCase(settings.getProperty("debug.sendServerSideTimings"))) {
             return;


### PR DESCRIPTION
What is the code smell/issue found?
Deprecated classes, interfaces should be avoided for using, inheriting, extending. Deprecation is basically an indication that a particular class has been superseded and will be eventually be removed. The deprecation period allows us to make a smooth transition away from the aging, soon-to-be-retired technology.

How is this code smell relevant?
Deprecated code is code that is very old in age and no longer being used, this can increase the complexity and will make maintainability of the code difficult.

How can we resolve this issue?
To resolve this issue we have removed "getSettings()" as it is deprecated and replaced it with "get_Settings()"
