### PR TITLE
String literals should not be duplicated #1

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
@@ -144,19 +144,19 @@ public abstract class ApplicationPageBase
             Authentication auth = SecurityContextHolder.getContext().getAuthentication();
             String username = auth != null ? auth.getName() : "SYSTEM";
             if (aMessage.isFatal()) {
-                LOG.error("{}: {}", username, aMessage.getMessage());
+                LOG.error(DUP_CON, username, aMessage.getMessage());
             }
             else if (aMessage.isError()) {
-                LOG.error("{}: {}", username, aMessage.getMessage());
+                LOG.error(DUP_CON, username, aMessage.getMessage());
             }
             else if (aMessage.isWarning()) {
-                LOG.warn("{}: {}", username, aMessage.getMessage());
+                LOG.warn(DUP_CON, username, aMessage.getMessage());
             }
             else if (aMessage.isInfo()) {
-                LOG.info("{}: {}", username, aMessage.getMessage());
+                LOG.info(DUP_CON, username, aMessage.getMessage());
             }
             else if (aMessage.isDebug()) {
-                LOG.debug("{}: {}", username, aMessage.getMessage());
+                LOG.debug(DUP_CON, username, aMessage.getMessage());
             }
             return true;
         });


### PR DESCRIPTION
What is the code smell/ issue?
String literals should not be duplicates.
How is this code smell/ issue relevant?
Using duplicate string literals can make the refactoring process error-prone and can also make the code less complex.
How can this issue be resolved?
Using constants instead of duplicating string literals can make the code less complex as constants can be referred from many places and can be updated in a single place.

