### PR TITLE
For any logging frameworks, standard outputs should not be used

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
+import java.util.logging.Logger;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.Component;
@@ -315,7 +316,7 @@ public abstract class WicketApplicationBase
         AnnotatedMountList mounts = new AnnotatedMountScanner().scanPackage("de.tudarmstadt.ukp");
         for (IRequestMapper mapper : mounts) {
             if (mapper instanceof HomePageMapper) {
-                System.out.println(mapper);
+                logger.log(mapper);
             }
         }
         mounts.mount(this);


### PR DESCRIPTION
What is the code smell/issue?
When logging a message, standard outputs should not be used directly to log in.
Why is it relevant?
If a program directly writes to the standard outputs, the user might not be able to easily retrieve the logs. And another concern is logged data and sensitive data may not be secured.
How to resolve it?
Replacing system.out.println() to logger.log() is highly recommended because it offers a lot of features such as controlling log level at run-time, provides high flexibility, and improvement in message quality. 
We have to import logging package to implement logger object, which is used log messages of a particular application 