### PR TITLE
Hard coded credential

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
@@ -45,6 +45,7 @@ import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.parameter.UrlRequestParametersAdapter;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.util.string.StringValue;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -70,7 +71,7 @@ public class LoginPage
     private static final long serialVersionUID = -333578034707672294L;
 
     private static final String ADMIN_DEFAULT_USERNAME = "admin";
-    private static final String ADMIN_DEFAULT_PASSWORD = "admin";
+    private static final String ADMIN_DEFAULT_PASSWORD = RandomStringUtils.randomAlphanumeric(10);
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 


### PR DESCRIPTION
What is the code smell/ issue?
Here on this page, the "PASSWORD" has been (hardcoded)stored in code that is not secure as the passwords should be stored outside the code in databases, etc.
How is the code smell relevant?
it is easy to extract strings from an application source code or binary, credentials should not be hard-coded. This is particularly true for applications that are distributed or that are open-source.
Credentials should be stored outside of the code in a configuration file, a database, or a management service for secrets.
This rule flags instances of hard-coded credentials used in database and LDAP connections. It looks for hard-coded credentials in connection strings and variable names that match any of the patterns from the provided list.
How can we resolve this issue?
To resolve this issue, we have imported an apache library containing RandomStringUtils class that allows generating an automatic password used as the admin's default password.