### PR TITLE
For any logging frameworks, standard outputs should not be used #1

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -51,6 +51,7 @@ import org.apache.wicket.resource.loader.IStringResourceLoader;
 import org.apache.wicket.resource.loader.NestedStringResourceLoader;
 import org.apache.wicket.settings.ExceptionSettings;
 import org.slf4j.MDC;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -315,7 +316,7 @@ public abstract class WicketApplicationBase
         AnnotatedMountList mounts = new AnnotatedMountScanner().scanPackage("de.tudarmstadt.ukp");
         for (IRequestMapper mapper : mounts) {
             if (mapper instanceof HomePageMapper) {
-                System.out.println(mapper);
+                logger.log(mapper);
             }
         }
         mounts.mount(this);


### PR DESCRIPTION
What is the code smell/issue?
When logging a message, standard outputs should not be used directly to log in.
Why is it relevant?
If a program directly writes to the standard outputs, the user might not be able to easily retrieve the logs. And another concern is logged data and sensitive data may not be secured.
How to resolve it?
Replacing system.out.println() to logger.log() is highly recommended because it offers a lot of features such as controlling log level at run-time, provides high flexibility, and improvement in message quality.
We have to import logging package to implement logger object, which is used log messages of a particular application